### PR TITLE
support nil masquerades and don't override explicitly set InsecureSkipVerify that overrides default false value

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -10,10 +10,8 @@ import (
 // HttpClient creates a simple domain-fronted HTTP client using the specified
 // values for the upstream host to use and for the masquerade/domain fronted host.
 func HttpClient(serverInfo *ServerInfo, masquerade *Masquerade) *http.Client {
-	if masquerade.RootCA == "" {
+	if masquerade != nil && masquerade.RootCA == "" {
 		serverInfo.InsecureSkipVerify = true
-	} else {
-		serverInfo.InsecureSkipVerify = false
 	}
 
 	enproxyConfig := serverInfo.buildEnproxyConfig(masquerade)


### PR DESCRIPTION
This is necessary for creating http clients that don't masquerade! We also don't want to override explicitly set InsecureSkipVerify setting on the ServerInfo.
