### PR TITLE
getlantern/lantern#1841 Added redial logic to buildEnproxyConfig

### DIFF
--- a/certs/cloud.yaml.tmpl
+++ b/certs/cloud.yaml.tmpl
@@ -7,6 +7,7 @@ client:
     masqueradeset: "cloudflare"
     insecureskipverify: false
     dialtimeoutmillis: 0
+    redialattempts: 2
     keepalivemillis: 0
     weight: 1
     qos: 5
@@ -15,6 +16,7 @@ client:
     masqueradeset: "cloudflare"
     insecureskipverify: false
     dialtimeoutmillis: 0
+    redialattempts: 2
     keepalivemillis: 0
     weight: 4000
     qos: 10
@@ -23,6 +25,7 @@ client:
     masqueradeset: "cloudflare"
     insecureskipverify: false
     dialtimeoutmillis: 0
+    redialattempts: 2
     keepalivemillis: 0
     weight: 1000
     qos: 2

--- a/client/config.go
+++ b/client/config.go
@@ -31,13 +31,17 @@ type ServerInfo struct {
 	// (defaults to 5 seconds)
 	DialTimeoutMillis int
 
+	// RedialAttempts: number of times to try redialing. The total number of
+	// dial attempts will be 1 + RedialAttempts.
+	RedialAttempts int
+
 	// KeepAliveMillis: interval for TCP keepalives (defaults to 70 seconds)
 	KeepAliveMillis int
 
 	// Weight: relative weight versus other servers (for round-robin)
 	Weight int
 
-	// QOS: relative quality of service offered.  Should be >= 0, with higher
+	// QOS: relative quality of service offered. Should be >= 0, with higher
 	// values indicating higher QOS.
 	QOS int
 }


### PR DESCRIPTION
This will redial twice using random masquerade hosts, for a total of 3 dial attempts before giving up.  We can tweak the redialattempts in the configuration.
