### PR TITLE
Proxybench now reports response_time with regular op

### DIFF
--- a/borda/borda.go
+++ b/borda/borda.go
@@ -42,9 +42,7 @@ func startBordaAndProxyBench(reportInterval time.Duration, enabled func() bool) 
 	reportToBorda := bordaClient.ReducingSubmitter("client_results", 1000)
 
 	proxybench.Start(&proxybench.Opts{}, func(timing time.Duration, ctx map[string]interface{}) {
-		if enabled() {
-			reportToBorda(map[string]borda.Val{"response_time": borda.Avg(timing.Seconds())}, ctx)
-		}
+		// No need to do anything, this is now handled with the regular op reporting
 	})
 
 	reporter := func(failure error, ctx map[string]interface{}) {

--- a/glide.lock
+++ b/glide.lock
@@ -189,7 +189,7 @@ imports:
 - name: github.com/getlantern/proxy
   version: 876829e39cf8243d123b02f02efe8da1266effb4
 - name: github.com/getlantern/proxybench
-  version: 7f2618cbbe1b32186001f31284cb81c58c302330
+  version: a491977af73a8a23c4089f5c6bf6dae7775ff697
 - name: github.com/getlantern/rot13
   version: 33f93fc1fe85c042c0667a1814e6379bd5e7eb40
 - name: github.com/getlantern/rotator


### PR DESCRIPTION
Fixes getlantern/lantern-internal#308

In coordination with this proxybench commit - https://github.com/getlantern/proxybench/commit/a491977af73a8a23c4089f5c6bf6dae7775ff697