### PR TITLE
include tests in subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ novendor:
 
 test-and-cover: $(SOURCES)
 	@echo "mode: count" > profile.cov && \
-	TP=$$(find . -type d  | grep -v vendor | grep -v git | grep -v "./genconfig/proxiedsites" | grep -v "status_pages") && \
+	TP=$$(find . -type d  | grep -v vendor | grep -v git | grep -v "./genconfig/proxiedsites" | grep -v "status_pages" | grep -v "test_zip_src") && \
 	CP=$$(echo -n $$TP | tr ' ', ',') && \
 	set -x && \
 	for pkg in $$TP; do \


### PR DESCRIPTION
Hey @atavism I realized our test setup wasn't including subdirectories (just noticed it with `pro/client` in particular).

That was an issue before your merge, but this change also picks up a failing test or two with new code in the merge.