### PR TITLE
Updated to latest sysproxy to set <local> as bypass on Windows

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -219,7 +219,7 @@ imports:
 - name: github.com/getlantern/stack
   version: 02f928aad224fbccd50d66edd776fc9d1e9f2f2b
 - name: github.com/getlantern/sysproxy
-  version: e5ffd4c79c631b4fbf52b4c1f04439583d3a6b15
+  version: febfa42c9ebf30cddf46eeaa474d7f0e2497e9cc
 - name: github.com/getlantern/systray
   version: cdae0bdf2aeae3ffb5ffe0cd2e2f83443ca9d104
 - name: github.com/getlantern/tarfs


### PR DESCRIPTION
This has the effect of selecting "Bypass proxy server for all local addresses".

Closes getlantern/lantern-internal#788

I tested this on both Windows 10 and Windows XP and confirmed that the box is checked.

Requires:

https://github.com/getlantern/sysproxy-cmd/pull/4
https://github.com/getlantern/sysproxy/pull/3