### PR TITLE
Not double-wrapping tcp connection for HTTPS with overhead tracking

### DIFF
--- a/chained/proxy.go
+++ b/chained/proxy.go
@@ -106,9 +106,9 @@ func newHTTPSProxy(name string, s *ChainedServerInfo, deviceID string, proToken 
 		defer op.End()
 
 		elapsed := mtime.Stopwatch()
-		conn, err := tlsdialer.DialTimeout(overheadDialer(false, func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		conn, err := tlsdialer.DialTimeout(func(network, addr string, timeout time.Duration) (net.Conn, error) {
 			return p.tcpDial(op)(timeout)
-		}), chainedDialTimeout,
+		}, chainedDialTimeout,
 			"tcp", p.addr, false, &tls.Config{
 				ClientSessionCache: sessionCache,
 				InsecureSkipVerify: true,


### PR DESCRIPTION
For getlantern/lantern-internal#900