### PR TITLE
update kcp-go 

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -175,7 +175,7 @@ imports:
 - name: github.com/getlantern/jibber_jabber
   version: 7346f98d2644252b9fc10b89af1f1858b2dc29b9
 - name: github.com/getlantern/kcp-go
-  version: 4d5ae726b8740577e9267a0800078be9d80dc527
+  version: d158f0615731685a667f3cd92d20ed261b2c4af6
 - name: github.com/getlantern/kcpwrapper
   version: fce6a30ae8fc58a72d18c0f8a1006bfd11516828
 - name: github.com/getlantern/keyman


### PR DESCRIPTION
Not sure if we missed updating this one in yesterday--here's the relevant PR: https://github.com/getlantern/kcp-go/pull/1