### PR TITLE
Use updated protected with regex fix

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -214,7 +214,7 @@ imports:
 - name: github.com/getlantern/profiling
   version: 2a15afbadcff99bac017e17af273b31d4510ddb8
 - name: github.com/getlantern/protected
-  version: 8a8f784326c0e6a83b3a7334818e9b719a4758e0
+  version: b0900930f8068ec3c024d6d022c16d75ddd8a163
 - name: github.com/getlantern/proxiedsites
   version: 996122c1374578a85a536445d7d7ae88d3ee5a35
 - name: github.com/getlantern/proxy


### PR DESCRIPTION
Update flashlight to use the latest version of protected (which has a fix for the regex used to extract the DNS server IP)

https://github.com/getlantern/protected/pull/10

