### PR TITLE
Skip pro requests if we don't have a user id yet

### DIFF
--- a/android/android_pro.go
+++ b/android/android_pro.go
@@ -333,6 +333,11 @@ func ProRequest(command string, session Session) bool {
 
 	log.Debugf("Received a %s pro request", command)
 
+	if command != "newuser" && session.GetUserID() == 0 {
+		log.Debugf("No user ID: not making %s request", command)
+		return false
+	}
+
 	commands := map[string]proFunc{
 		"emailexists":          emailExists,
 		"newuser":              newUser,


### PR DESCRIPTION
Related to https://github.com/getlantern/lantern-internal/issues/1357

There's a few Pro requests made every time the app is open (to fetch things like the latest plan prices, user status, etc.) When its the very first time, and there's no user ID yet, these calls fail depending on the order they're made. This just skips making those requests if we don't have a user ID yet. 