### PR TITLE
Don't ad block if ad swapping is enabled

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -233,15 +233,16 @@ func (client *Client) initEasyList(adBlockingAllowed func() bool) {
 		return
 	}
 
+	combined := easylist.AndList{lanternList, easylistList}
+
 	client.easylist = easylist.ListFunc(func(req *http.Request) bool {
 		adSwappingEnabled := client.adSwapTargetURL() != ""
 		if adSwappingEnabled {
 			// Always allow to avoid interfering with ad swapping
 			return true
 		}
-		// Use lanternList and easylistList for maximum
-		// coverage
-		return lanternList.Allow(req) && easylistList.Allow(req)
+		// Use combined for maximum coverage
+		return combined.Allow(req)
 	})
 	log.Debug("Initialized easylist")
 }

--- a/client/handler_test.go
+++ b/client/handler_test.go
@@ -93,9 +93,8 @@ func TestAdBlockingFree(t *testing.T) {
 	client := newClient()
 	// Give us a chance to fetch the latest easylist and lanternlist
 	time.Sleep(5 * time.Second)
-	assertAllow(t, client, "http://googleads.g.doubleclick.net", false)
-	assertAllow(t, client, "http://www.googleadservices.com", false)
-	assertAllow(t, client, "http://cdn.adblade.com", true)
+	// On free, nothing should be blocked
+	assertAllow(t, client, "https://cdn.adblade.com", true)
 }
 
 func TestAdBlockingPro(t *testing.T) {


### PR DESCRIPTION
I didn't notice the problem on Windows, but for some reason on Mac, blocking Google ads with our aggressive lanternlist rules breaks ad swapping. This PR completely disables ad blocking for Free so that we don't take any chances with ad swapping working.