### PR TITLE
Including proxy information with traffic reporting

### DIFF
--- a/chained/dialer.go
+++ b/chained/dialer.go
@@ -327,7 +327,7 @@ func (p *proxy) onRequest(req *http.Request) {
 }
 
 func (p *proxy) onFinish(op *ops.Op) {
-	op.ChainedProxy(p.addr, p.protocol, p.network)
+	op.ChainedProxy(p.Name(), p.Addr(), p.Protocol(), p.Network())
 }
 
 func (p *proxy) sendCONNECT(addr string, conn net.Conn) error {

--- a/chained/probe.go
+++ b/chained/probe.go
@@ -57,7 +57,7 @@ func (p *proxy) httpPing(kb int, resetBBR bool) error {
 	httpPingMx.Lock()
 	defer httpPingMx.Unlock()
 
-	op := ops.Begin("probe").ChainedProxy(p.Addr(), p.Protocol(), p.Network())
+	op := ops.Begin("probe").ChainedProxy(p.Name(), p.Addr(), p.Protocol(), p.Network())
 	defer op.End()
 
 	start := time.Now()

--- a/chained/proxy.go
+++ b/chained/proxy.go
@@ -389,6 +389,7 @@ func newProxy(name, protocol, network, addr string, s *ChainedServerInfo, device
 		if err != nil {
 			return nil, err
 		}
+		p.protocol = "kcp"
 	}
 
 	go p.runConnectivityChecks()
@@ -610,7 +611,7 @@ func timeoutFor(ctx context.Context) time.Duration {
 }
 
 func (p *proxy) reportedDial(addr, protocol, network string, dial func(op *ops.Op) (net.Conn, error)) (serverConn, error) {
-	op := ops.Begin("dial_to_chained").ChainedProxy(addr, protocol, network)
+	op := ops.Begin("dial_to_chained").ChainedProxy(p.Name(), addr, protocol, network)
 	defer op.End()
 
 	elapsed := mtime.Stopwatch()

--- a/chained/ratetracking.go
+++ b/chained/ratetracking.go
@@ -31,7 +31,7 @@ func (p *proxy) withRateTracking(wrapped net.Conn, origin string) net.Conn {
 			p.consecRWSuccesses.Dec()
 		}
 		// record simple traffic without origin
-		op := ops.Begin("traffic")
+		op := ops.Begin("traffic").ChainedProxy(p.Name(), p.Addr(), p.Protocol(), p.Network())
 		op.SetMetric("client_bytes_sent", borda.Sum(stats.SentTotal)).
 			SetMetric("client_bytes_recv", borda.Sum(stats.RecvTotal))
 		op.FailIf(rwError)

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -2,10 +2,12 @@ package ops
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/getlantern/ops"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRequest(t *testing.T) {
@@ -39,4 +41,25 @@ func TestRequest(t *testing.T) {
 			assert.Equal(t, port, ctx["origin_port"])
 		}
 	}
+}
+
+func TestProxyName(t *testing.T) {
+	runTest := func(expectMatch bool, name string, expectedName, expectedDatacenter string) {
+		op := Begin("testop").ProxyName(name)
+		ctx := ops.AsMap(op, false)
+		op.End()
+		if !expectMatch {
+			assert.Empty(t, ctx["proxy_name"])
+			assert.Empty(t, ctx["dc"])
+		} else {
+			assert.Equal(t, expectedName, ctx["proxy_name"])
+			assert.Equal(t, expectedDatacenter, ctx["dc"])
+		}
+	}
+
+	runTest(true, "fp-https-donyc3-20180101-006-kcp", "fp-https-donyc3-20180101-006", "donyc3")
+	runTest(true, "fp-donyc3-20180101-006-kcp", "fp-donyc3-20180101-006", "donyc3")
+	runTest(true, "fp-donyc3-20180101-006", "fp-donyc3-20180101-006", "donyc3")
+	runTest(false, "fp-14325-adsfds-006", "", "")
+	runTest(false, "cloudcompile", "", "")
 }


### PR DESCRIPTION
For getlantern/lantern-internal#1826

It turns out that we already track a "traffic" metric from the client-side that has almost everything we need. For some reason we just weren't including the proxy info. We do that now.