### PR TITLE
Add http client timeouts

### DIFF
--- a/autoupdate/autoupdate.go
+++ b/autoupdate/autoupdate.go
@@ -34,6 +34,7 @@ func Configure(updateURL, updateCA string, iconURL func() string) {
 	fnIconURL = iconURL
 	httpClient.Store(
 		&http.Client{
+			Timeout:   time.Second * 30,
 			Transport: proxied.ChainedThenFrontedWith("d2yl1zps97e5mx.cloudfront.net", updateCA),
 		})
 	enableAutoupdate()

--- a/borda/borda.go
+++ b/borda/borda.go
@@ -120,6 +120,7 @@ func createBordaClient(reportInterval time.Duration) *borda.Client {
 	return borda.NewClient(&borda.Options{
 		BatchInterval: reportInterval,
 		HTTPClient: &http.Client{
+			Timeout: time.Second * 30,
 			Transport: proxied.AsRoundTripper(func(req *http.Request) (*http.Response, error) {
 				frontedURL := *req.URL
 				frontedURL.Host = "d157vud77ygy87.cloudfront.net"

--- a/pro/http.go
+++ b/pro/http.go
@@ -2,6 +2,7 @@ package pro
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/getlantern/flashlight/common"
 	"github.com/getlantern/flashlight/proxied"
@@ -20,6 +21,7 @@ func GetHTTPClient() *http.Client {
 
 func getHTTPClient(getRt, otherRt http.RoundTripper) *http.Client {
 	return &http.Client{
+		Timeout: time.Second * 30,
 		Transport: proxied.AsRoundTripper(func(req *http.Request) (*http.Response, error) {
 			if req.Method == "GET" || req.Method == "HEAD" {
 				return getRt.RoundTrip(req)


### PR DESCRIPTION
This should fix https://github.com/getlantern/lantern-internal/issues/1867 which currently happens in part because the call to borda somehow only times out after 4 mins.