### PR TITLE
Added is_data_capped global dimension for borda reporting

### DIFF
--- a/flashlight.go
+++ b/flashlight.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/getlantern/appdir"
+	"github.com/getlantern/bandwidth"
 	fops "github.com/getlantern/flashlight/ops"
 	"github.com/getlantern/flashlight/shortcut"
 	"github.com/getlantern/fronted"
@@ -267,6 +268,13 @@ func initContext(deviceID string, version string, revisionDate string, isPro fun
 	})
 	ops.SetGlobalDynamic("is_pro", func() interface{} {
 		return isPro()
+	})
+	ops.SetGlobalDynamic("is_data_capped", func() interface{} {
+		if isPro() {
+			return false
+		}
+		quota := bandwidth.GetQuota()
+		return quota != nil && quota.MiBUsed >= quota.MiBAllowed
 	})
 
 	if osStr, err := osversion.GetHumanReadable(); err == nil {


### PR DESCRIPTION
For getlantern/lantern-internal#2098.

I tested by temporarily adding some logging to our borda reporter to spit out the reported context. I then:

1. Ran as free and verified that when I'm data capped, I see `is_data_capped: true`
2. Linked to my pro account and verified that I then see `is_data_capped: false`