### PR TITLE
Record when the proxy op is actually using a remote proxy

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -447,6 +447,7 @@ func (client *Client) doDial(op *ops.Op, ctx context.Context, isCONNECT bool, ad
 
 func (client *Client) getDialer(op *ops.Op, isCONNECT bool) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	dialProxied := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		op.Set("remotely_proxied", true)
 		proto := "persistent"
 		if isCONNECT {
 			// UGLY HACK ALERT! In this case, we know we need to send a CONNECT request


### PR DESCRIPTION
This will let us filter out direct dials from our statistics.