### PR TITLE
Add missing data centers to `dcLocs`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -283,7 +283,7 @@ func (client *Client) reportProxyLocationLoop() {
 			activeProxy = proxy.Name()
 			loc := proxyLoc(activeProxy)
 			if loc == nil {
-				log.Errorf("Couldn't find location for %s", activeProxy)
+				log.Debugf("Couldn't find location for %s", activeProxy)
 				continue
 			}
 			client.statsTracker.SetActiveProxyLocation(

--- a/client/proxy_loc.go
+++ b/client/proxy_loc.go
@@ -23,6 +23,16 @@ var (
 			"India",
 			"IN",
 		},
+		"dofra1": &location{
+			"Frankfurt",
+			"Germany",
+			"DE",
+		},
+		"dolon1": &location{
+			"London",
+			"United Kingdom",
+			"GB",
+		},
 		"dosgp1": &location{
 			"Singapore",
 			"Singapore",
@@ -48,6 +58,11 @@ var (
 			"Japan",
 			"JP",
 		},
+		"litok2": &location{
+			"Tokyo",
+			"Japan",
+			"JP",
+		},
 		"xfkrkt": &location{
 			"Seoul",
 			"Korea",
@@ -57,6 +72,21 @@ var (
 			"Changhua",
 			"Taiwan",
 			"TW",
+		},
+		"vllhr1": &location{
+			"London",
+			"United Kingdom",
+			"GB",
+		},
+		"vllos1": &location{
+			"Los Angeles",
+			"United States",
+			"US",
+		},
+		"vlsgp1": &location{
+			"Singapore",
+			"Singapore",
+			"SG",
 		},
 		"vltok1": &location{
 			"Tokyo",


### PR DESCRIPTION
Also change error message about missing location to debug message.

Fixes the following error we were seeing in Iran logs:

```
Aug 27 01:37:17.605 - 0m4s ERROR flashlight.client: client.go:286 Couldn't find location for fp-dofra1-20180822-454-lampshade [error=Couldn't find location for %s error_location=github.com/getlantern/flashlight/client.(*Client).reportProxyLocationLoop.func1 (client.go:286) error_text=Couldn't find location for fp-dofra1-20180822-454-lampshade error_type=errors.Error]
ERROR flashlight.client: client.go:286   at github.com/getlantern/flashlight/client.(*Client).reportProxyLocationLoop.func1 (client.go:286)
ERROR flashlight.client: client.go:286   at runtime.goexit (asm_arm.s:1015)
```