### PR TITLE
Reduce preconnects, locking fix, and more stats

### DIFF
--- a/chained/proxy.go
+++ b/chained/proxy.go
@@ -40,8 +40,8 @@ import (
 const (
 	trustedSuffix = " (t)"
 
-	defaultInitPreconnect = 20
-	defaultMaxPreconnect  = 100
+	defaultInitPreconnect = 1
+	defaultMaxPreconnect  = 4
 
 	// Below two values are based on suggestions in rfc6298
 	rttAlpha    = 0.125


### PR DESCRIPTION
This dramatically reduces the amount of preconnecting we do while seemingly keeping it effective at significantly reduce average round trip request times. 

In my tests this change reduces my average "connect" time for CONNECT requests from about **650ms to about 250ms** and for persistent requests from **300ms to 0ms** versus no predialing of connections. This should also significantly reduce the additional detectability of idle connections from a blocking resistance perspective while also making us much less likely to run into any bugs related to idle timeouts on connections that have been sitting around for awhile.