### PR TITLE
Using domain-fronting if submitting email directly to Mandrill fails

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -29,6 +29,7 @@ var (
 		"update.getlantern.org":            "d2yl1zps97e5mx.cloudfront.net",
 		"github.com":                       "d2yl1zps97e5mx.cloudfront.net",
 		"github-production-release-asset-2e65be.s3.amazonaws.com": "d37kom4pw4aa7b.cloudfront.net",
+		"mandrillapp.com":                                         "d2rh3u0miqci5a.cloudfront.net",
 	}
 )
 

--- a/flashlight.go
+++ b/flashlight.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/getlantern/appdir"
 	"github.com/getlantern/bandwidth"
+	"github.com/getlantern/flashlight/email"
 	fops "github.com/getlantern/flashlight/ops"
 	"github.com/getlantern/flashlight/shortcut"
 	"github.com/getlantern/fronted"
@@ -77,6 +78,7 @@ func Run(httpProxyAddr string,
 	elapsed := mtime.Stopwatch()
 	displayVersion()
 	initContext(userConfig.GetDeviceID(), common.Version, common.RevisionDate, isPro, userID)
+	email.SetHTTPClient(proxied.DirectThenFrontedClient(1 * time.Minute))
 	op := fops.Begin("client_started")
 
 	cl, err := client.NewClient(

--- a/genconfig/genconfig.go
+++ b/genconfig/genconfig.go
@@ -97,6 +97,7 @@ func init() {
 			"update.getlantern.org":            "update.dsa.akamai.getiantem.org",
 			"github.com":                       "github.dsa.akamai.getiantem.org",
 			"github-production-release-asset-2e65be.s3.amazonaws.com": "github-release-asset.dsa.akamai.getiantem.org",
+			"mandrillapp.com":                                         "mandrillapp.dsa.akamai.getiantem.org",
 		},
 		&client.ValidatorConfig{RejectStatus: []int{403}},
 	)
@@ -113,6 +114,7 @@ func init() {
 			"update.getlantern.org":            "update.edgecast.getiantem.org",
 			"github.com":                       "github.edgecast.getiantem.org",
 			"github-production-release-asset-2e65be.s3.amazonaws.com": "github-release-asset.edgecast.getiantem.org",
+			"mandrillapp.com":                                         "mandrillapp.edgecast.getiantem.org",
 		},
 		&client.ValidatorConfig{RejectStatus: []int{403}},
 	)
@@ -616,7 +618,7 @@ func buildModel(configName string, cas map[string]*castat, useFallbacks bool) (m
 		}
 	}
 	return map[string]interface{}{
-		"cas":                   casList,
+		"cas": casList,
 		"cloudfrontMasquerades": cfMasquerades,
 		"providers":             enabledProviders,
 		"proxiedsites":          ps,


### PR DESCRIPTION
For getlantern/lantern-internal#2369.

I tested this both using the disabled `testSubmitIssue` function and by submitting an issue through the Lantern UI. To make sure domain-fronting is used, I added this entry in /etc/hosts:

```
0.0.0.0 mandrillapp.com
```

I've tested with Cloudfront, still need to test with Akamai and Edgecast.