### PR TITLE
[RFR] Yinbi-154: Set `yinbiEnabled` based on `pro-server` call

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -40,6 +40,7 @@ func (m mockStatsTracker) SetDisconnected(val bool)                             
 func (m mockStatsTracker) SetHasSucceedingProxy(val bool)                           {}
 func (m mockStatsTracker) SetHitDataCap(val bool)                                   {}
 func (m mockStatsTracker) SetIsPro(val bool)                                        {}
+func (m mockStatsTracker) SetYinbiEnabled(val bool)                                 {}
 func (m mockStatsTracker) SetAlert(stats.AlertType, string, bool)                   {}
 func (m mockStatsTracker) ClearAlert(stats.AlertType)                               {}
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -74,8 +74,9 @@ func (app *App) Init() {
 	settings = loadSettings(common.Version, common.RevisionDate, common.BuildDate, common.Staging)
 	app.exited = eventual.NewValue()
 	app.statsTracker = NewStatsTracker()
-	pro.OnProStatusChange(func(isPro bool) {
+	pro.OnProStatusChange(func(isPro bool, yinbiEnabled bool) {
 		app.statsTracker.SetIsPro(isPro)
+		app.statsTracker.SetYinbiEnabled(yinbiEnabled)
 	})
 	settings.OnChange(SNDisconnected, func(disconnected interface{}) {
 		isDisconnected := disconnected.(bool)

--- a/desktop/settings.go
+++ b/desktop/settings.go
@@ -50,8 +50,6 @@ const (
 	SNBuildDate    SettingName = "buildDate"
 	SNRevisionDate SettingName = "revisionDate"
 	SNPACURL       SettingName = "pacURL"
-
-	SNYinbiEnabled SettingName = "yinbiEnabled"
 )
 
 type settingType byte
@@ -91,8 +89,6 @@ var settingMeta = map[SettingName]struct {
 	SNBuildDate:    {stString, false, false},
 	SNRevisionDate: {stString, false, false},
 	SNPACURL:       {stString, true, true},
-
-	SNYinbiEnabled: {stBool, false, false},
 }
 
 var (
@@ -186,7 +182,6 @@ func newSettings(filePath string) *Settings {
 			SNUserToken:      "",
 			SNUIAddr:         "",
 			SNPACURL:         "",
-			SNYinbiEnabled:   true,
 		},
 		filePath:        filePath,
 		changeNotifiers: make(map[SettingName][]func(interface{})),
@@ -469,12 +464,6 @@ func (s *Settings) GetInternalHeaders() map[string]string {
 // GetSystemProxy returns whether or not to set system proxy when lantern starts
 func (s *Settings) GetSystemProxy() bool {
 	return s.getBool(SNSystemProxy)
-}
-
-// GetYinbiEnabled returns whether or not the user should participate in the
-// Yinbi giveaway
-func (s *Settings) GetYinbiEnabled() bool {
-	return s.getBool(SNYinbiEnabled)
 }
 
 // SetPACURL sets the last used PAC URL. Note this is used particularl on

--- a/pro/client/user.go
+++ b/pro/client/user.go
@@ -18,6 +18,7 @@ type User struct {
 	Code          string   `json:"code"`
 	ExpireAt      int64    `json:"expireAt"`
 	Referral      string   `json:"referral"`
+	YinbiEnabled  bool     `json:"yinbiEnabled"`
 	Auth          `json:",inline"`
 }
 

--- a/pro/user_data.go
+++ b/pro/user_data.go
@@ -15,17 +15,17 @@ var logger = golog.LoggerFor("flashlight.app.pro")
 type userMap struct {
 	sync.RWMutex
 	data        map[int64]eventual.Value
-	onProStatus []func(isPro bool)
+	onProStatus []func(isPro bool, yinbiEnabled bool)
 }
 
 var userData = userMap{
 	data:        make(map[int64]eventual.Value),
-	onProStatus: make([]func(isPro bool), 0),
+	onProStatus: make([]func(isPro bool, yinbiEnabled bool), 0),
 }
 
 // OnProStatusChange allows registering an event handler to learn when the
-// user's pro status has changed.
-func OnProStatusChange(cb func(isPro bool)) {
+// user's pro status or "yinbi enabled" status has changed.
+func OnProStatusChange(cb func(isPro bool, yinbiEnabled bool)) {
 	userData.Lock()
 	userData.onProStatus = append(userData.onProStatus, cb)
 	userData.Unlock()
@@ -42,8 +42,9 @@ func (m *userMap) save(userID int64, u *client.User) {
 	onProStatus := m.onProStatus
 	m.Unlock()
 	isPro := isActive(u.UserStatus)
+	yinbiEnabled := u.YinbiEnabled
 	for _, cb := range onProStatus {
-		cb(isPro)
+		cb(isPro, yinbiEnabled)
 	}
 }
 

--- a/stats/stats_tracker.go
+++ b/stats/stats_tracker.go
@@ -79,6 +79,10 @@ type Tracker interface {
 	// SetIsPro indicates that we're pro
 	SetIsPro(val bool)
 
+	// SetYinbiEnabled indicates that the user is eligible to participate in the
+	// Yinbi giveaway
+	SetYinbiEnabled(val bool)
+
 	// SetAlert indicates that some alert needs user attention. If transient is
 	// true, the alert will be cleared automatically 10 seconds later.
 	SetAlert(alertType AlertType, details string, transient bool)
@@ -99,6 +103,7 @@ type Stats struct {
 	HasSucceedingProxy bool    `json:"hasSucceedingProxy"`
 	HitDataCap         bool    `json:"hitDataCap"`
 	IsPro              bool    `json:"isPro"`
+	YinbiEnabled       bool    `json:"yinbiEnabled"`
 	Status             string  `json:"status"`
 	Alerts             []Alert `json:"alerts"`
 }
@@ -176,6 +181,13 @@ func (t *tracker) SetHitDataCap(val bool) {
 func (t *tracker) SetIsPro(val bool) {
 	t.update(func(stats Stats) Stats {
 		stats.IsPro = val
+		return stats
+	})
+}
+
+func (t *tracker) SetYinbiEnabled(val bool) {
+	t.update(func(stats Stats) Stats {
+		stats.YinbiEnabled = val
 		return stats
 	})
 }


### PR DESCRIPTION
https://github.com/getlantern/yinbi-server/issues/154

Previously, we were hardcoding `yinbiEnabled = true` in flashlight and sending that as part of the settings message to the UI, rather than reading from the pro-server `/user-data` response.

The `statsTracker` is currently what responds to a change in user Pro status detected through the `/user-data` call, so it made sense to set `YinbiEnabled` here as well since it comes back in the same API call, vs. in settings which just loads in settings from a file.

Note that this introduces a breaking change in the Desktop UI -- I will open a PR there to resolve that momentarily.