### PR TITLE
Don't add wrap lampshade TCP connections with IdleTiming

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -439,11 +439,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a94a9658bf10d3e53b805b0f6ba40d65da3c2625975731646771e1623848c68e"
+  digest = "1:349cd7781b821a13bf9a005fa2f5b6c78c4248e477bc3b869e01bb601c1e6cdd"
   name = "github.com/getlantern/idletiming"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1ee14e2c3fde60192f6d6a1d5748ffafe487bb75"
+  revision = "d6af7c708ed589011044d1ca79945bbbaa42056e"
 
 [[projects]]
   branch = "master"
@@ -490,11 +490,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7b753a58505179be72fe557381d83a17719487952ee2a6306c2cc78f81fc363d"
+  digest = "1:1e260c564c8d608f74841d250d5065f3ad59adc927c2471b067b95529a5e695f"
   name = "github.com/getlantern/lampshade"
   packages = ["."]
   pruneopts = "UT"
-  revision = "44db2076fd5bf00175d91088b7679a4a310b9bfa"
+  revision = "00e09a522d61d090a915959ad678c6a63388c62f"
 
 [[projects]]
   branch = "master"

--- a/chained/probe.go
+++ b/chained/probe.go
@@ -18,6 +18,16 @@ import (
 	"github.com/getlantern/mtime"
 )
 
+var (
+	// PerformanceProbes determines how many times to probe for performance on
+	// each call to Probe()
+	PerformanceProbes = 5
+
+	// BasePerformanceProbeKB is the minimum number of KB to request from ping
+	// endpoint when probing for performance
+	BasePerformanceProbeKB = 50
+)
+
 func (p *proxy) ProbeStats() (successes uint64, successKBs uint64, failures uint64, failedKBs uint64) {
 	return atomic.LoadUint64(&p.probeSuccesses), atomic.LoadUint64(&p.probeSuccessKBs),
 		atomic.LoadUint64(&p.probeFailures), atomic.LoadUint64(&p.probeFailedKBs)
@@ -54,10 +64,10 @@ func (p *proxy) Probe(forPerformance bool) bool {
 
 	// probing for performance, do several increasingly large pings
 	var kb int
-	for i := 0; i < 5; i++ {
+	for i := 0; i < PerformanceProbes; i++ {
 		// we vary the size of the ping request to help the BBR curve-fitting
 		// logic on the server.
-		kb = 50 + i*25
+		kb = BasePerformanceProbeKB + i*25
 		// Ask the proxy to reset BBR stats to have an up-to-date estimation
 		// after the probe.
 		err := p.httpPing(kb, i == 0)

--- a/chained/proxy.go
+++ b/chained/proxy.go
@@ -264,13 +264,10 @@ func newLampshadeProxy(name string, s *ChainedServerInfo, uc common.UserConfig) 
 				Set("ls_streams", int(maxStreamsPerConn)).
 				Set("ls_cipher", cipherCode.String())
 			conn, err := dialer.Dial(func() (net.Conn, error) {
-				conn, err := p.dialCore(op)(ctx)
-				if err == nil && idleInterval > 0 {
-					conn = idletiming.Conn(conn, idleInterval, func() {
-						log.Debug("lampshade TCP connection idled")
-					})
-				}
-				return conn, err
+				// note - we do not wrap the TCP connection with IdleTiming because
+				// lampshade cleans up after itself and won't leave excess unused
+				// connections hanging around.
+				return p.dialCore(op)(ctx)
 			})
 			return overheadWrapper(true)(conn, err)
 		})

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -1,0 +1,84 @@
+// prober is a utility program that will continuously probe a proxy
+// configuration with a randomly varying pause between probes to exercise
+// IdleTiming functionality. Call the program with a single argument pointing
+// to a file that contains configuration YAML for a single proxy, like so:
+//
+// addr: 178.128.93.8:443
+// cert: "-----BEGIN CERTIFICATE-----\nMIIDiTCCAnGgAwIBAgIJAK7xb7u2yR3/MA0GCSqGSIb3DQEBCwUAMGoxGzAZBgNV\nBAMTEllhbWFoYSBTdWJzdGFuZGFyZDEaMBgGA1UEChMRQmxhc3BoZW1pbmcgQWxw\naGExDTALBgNVBAcTBEdhbmcxEzARBgNVBAgTCk5ldyBKZXJzZXkxCzAJBgNVBAYT\nAlVTMB4XDTE4MTEyMDE5MzgyNFoXDTE5MTEyMDE5MzgyNFowajEbMBkGA1UEAxMS\nWWFtYWhhIFN1YnN0YW5kYXJkMRowGAYDVQQKExFCbGFzcGhlbWluZyBBbHBoYTEN\nMAsGA1UEBxMER2FuZzETMBEGA1UECBMKTmV3IEplcnNleTELMAkGA1UEBhMCVVMw\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDF0RWp9G3A5b6dR+TbP/vM\nyUwYb9IXzVxSBaFpsc13M3BztS6384dFAWkT6fHRp5r/Hs/cNx+0Oj/0bEC7GFGb\nPbs/S3BAD2i5qiz/ly9Qf1E82WeHYVgcIej35UvR1LJeYO8svgNMmhxtOOej9xoD\nov3mRwEaZicaKTYaNYab0LHLelLZZqRiJr8AuylsjE9EVzArbiNbm6PReZsEDssF\nKjjris3GxjTHF2+BHjd/GMTsB0tqvgf67dRahhY6XMG74HAcyFR7cDi2EzQOraAB\nJ3qyVjFKUTXhhb+Ra3eLaGqnFSwIYr5BLdwWfIZ0f8UakDTJ78Wy7xWFqzHKoh3H\nAgMBAAGjMjAwMB0GA1UdDgQWBBSLD84YzwP8ltOtMsmcRvV7loqJRTAPBgNVHREE\nCDAGhwSygF0IMA0GCSqGSIb3DQEBCwUAA4IBAQA6eRqyzZ4rDrd5BDLuxo9dbvtu\nJedcB61T877NRpO/3fRZrUH6Fgv+hl1C0WDIggYLPvAb74Q6D7AWX9mLFrsqQdUE\nqI373o2vNe9jLE+/5Xuphq6Thtsw94SjtSfukMBm7UmxGcuaooDAcg77R5b0i1pf\n4qc4dLOcVFjdlii3snCcZzj3gS62YCP7IdWNagYKiLXtPMlBNOL6Swi6eGbaLMHb\nQSSI8A3Dl4xcFkwpWTrYTUQiLJQF+URvpDoKF5QT4ux5v+eDeYmXP2tE5/HYsUH4\nhoy5jzWlcHCs7cq+Wl4LflFnXPceARg/SjvXQx40q+6Cq5R7YoIuK1DrR3iB\n-----END
+//   CERTIFICATE-----\n"
+// authtoken: wMJEBd1uUWeSakripkBYBiI5SGVn8685YjesoWrkml5jzxOj4Rk6tYMR3oFTEu4C
+// trusted: true
+// maxpreconnect: 0
+// bias: 0
+// pluggabletransport: lampshade
+// pluggabletransportsettings: {}
+// kcpsettings: {}
+// enhttpurl: ""
+// tlsdesktoporderedciphersuitenames: []
+// tlsmobileorderedciphersuitenames: []
+// tlsservernameindicator: ""
+// tlsclientsessioncachesize: 0
+// tlsclienthelloid: ""
+// location:
+//   city: Singapore
+//   country: Singapore
+//   countrycode: ""
+//   latitude: 1.29
+//   longitude: 103.86
+// multiplexedaddr: ""
+// multiplexedphysicalconns: 0
+
+package main
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/getlantern/golog"
+	"github.com/getlantern/yaml"
+
+	"github.com/getlantern/flashlight/chained"
+	"github.com/getlantern/flashlight/common"
+)
+
+var (
+	log = golog.LoggerFor("prober")
+)
+
+func main() {
+	chained.IdleTimeout = 2 * time.Second
+	chained.PerformanceProbes = 1
+	chained.BasePerformanceProbeKB = 100
+
+	cfg, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		log.Fatalf("Unable to read config from %v: %v", os.Args[1], err)
+	}
+	server := &chained.ChainedServerInfo{}
+	err = yaml.Unmarshal(cfg, server)
+	if err != nil {
+		log.Fatalf("Unable to read yaml config: %v", err)
+	}
+
+	dialer, err := chained.CreateDialer(os.Args[1], server, &common.UserConfigData{
+		DeviceID: "XXXXXXXX",
+		UserID:   0,
+		Token:    "protoken",
+	})
+	if err != nil {
+		log.Fatalf("Unable to create dialer: %v", err)
+	}
+
+	log.Debugf("Will probe %v", dialer.Label())
+	for {
+		if !dialer.Probe(true) {
+			return
+		}
+
+		sleepTime := time.Duration(float64(chained.IdleTimeout) * 3 * rand.Float64())
+		log.Debugf("Sleeping %v", sleepTime)
+		time.Sleep(sleepTime)
+	}
+}


### PR DESCRIPTION
For getlantern/lantern-internal#2373

~~Depends on https://github.com/getlantern/lampshade/pull/22~~

Instead of using IdleTiming to clean up the underlying lampshade TCP connections, we now rely on lampshade to clean up after itself.