### PR TITLE
Check for go-bindata bin location and verison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ require-dep:
 
 # test go-bindata dependency and update icons if up-to-date
 update-icons:
-	@if [ "$(GOBINDATA_BIN)" = "" ]; then \
+	@if [[ -z "$(GOBINDATA_BIN)" ]]; then \
 		echo 'Missing dependency go-bindata, get with: go get -u github.com/kevinburke/go-bindata/...' && exit 1; \
 	fi; \
 	GOBINDATA_VERSION=`grep jteeuwen $(GOBINDATA_BIN)`; \


### PR DESCRIPTION
See getlantern/lantern-internal#2473; adds additional support for prompting users to upgrade dependency
- [x] Check for the location and version of go-bindata. 
- [x] Prompt user of `make update-icons` to upgrade to the best supported version https://github.com/kevinburke/go-bindata

@oxtoacart could you take a look at this when you have the time? Thanks!