### PR TITLE
Added balancer_dial_details to capture details of balancer dials

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -234,6 +234,9 @@ func (b *Balancer) DialContext(ctx context.Context, network, addr string) (net.C
 	op := ops.Begin("balancer_dial").Set("beam", atomic.AddUint64(&b.beam_seq, 1))
 	defer op.End()
 
+	op = ops.Begin("balancer_dial_details")
+	defer op.End()
+
 	start := time.Now()
 	bd, err := b.newBalancedDial(network, addr)
 	if err != nil {


### PR DESCRIPTION
This is necessary because "balancer_dial" is a "lightweight" op which means that we don't report much about it. Adding "balancer_dial_details" inside of "balancer_dial" gives us an op that reports full details but is only partially sampled, so won't flood borda with data.