### PR TITLE
Logging for CORS test

### DIFF
--- a/client/handler_test.go
+++ b/client/handler_test.go
@@ -50,8 +50,9 @@ func TestRewriteHTTPSCORS(t *testing.T) {
 	client.rewriteToHTTPS = httpseverywhere.Eager()
 	req, _ := http.NewRequest("GET", "http://www.adaptec.com/", nil)
 	req.Header.Set("Origin", "www.adaptec.com")
+	log.Debug("Starting CORS roundtrip")
 	resp, err := roundTrip(client, req)
-	log.Debug("Finished round trip")
+	log.Debug("Finished CORS round trip")
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
The CORS test is sometimes hanging in CI. This should help with debugging.