### PR TITLE
Fixed config test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ lantern.zip
 access_data.json
 cloud.yaml.tmpl
 demo
+.vscode

--- a/ios/config_test.go
+++ b/ios/config_test.go
@@ -4,6 +4,9 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"path/filepath"
+	"strings"
+	"sort"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -19,42 +22,44 @@ func TestConfigure(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(tmpDir)
-	/*
-		ioutil.WriteFile(filepath.Join(tmpDir, "global.yaml"), []byte{}, 0644)
-		ioutil.WriteFile(filepath.Join(tmpDir, "global.yaml.etag"), []byte{}, 0644)
-		ioutil.WriteFile(filepath.Join(tmpDir, "proxies.yaml"), []byte{}, 0644)
-		ioutil.WriteFile(filepath.Join(tmpDir, "proxies.yaml.etag"), []byte{}, 0644)
-		ioutil.WriteFile(filepath.Join(tmpDir, "masquerade_cache"), []byte{}, 0644)
-		ioutil.WriteFile(filepath.Join(tmpDir, "userconfig.yaml"), []byte{}, 0644)
 
-		result1, err := Configure(tmpDir, testDeviceID1)
-		if !assert.NoError(t, err) {
-			return
-		}
+	ioutil.WriteFile(filepath.Join(tmpDir, "global.yaml"), []byte{}, 0644)
+	ioutil.WriteFile(filepath.Join(tmpDir, "global.yaml.etag"), []byte{}, 0644)
+	ioutil.WriteFile(filepath.Join(tmpDir, "proxies.yaml"), []byte{}, 0644)
+	ioutil.WriteFile(filepath.Join(tmpDir, "proxies.yaml.etag"), []byte{}, 0644)
+	ioutil.WriteFile(filepath.Join(tmpDir, "masquerade_cache"), []byte{}, 0644)
+	ioutil.WriteFile(filepath.Join(tmpDir, "userconfig.yaml"), []byte{}, 0644)
 
-		assert.True(t, result1.VPNNeedsReconfiguring)
-		assert.NotEmpty(t, result1.IPSToExcludeFromVPN)
+	result1, err := Configure(tmpDir, testDeviceID1)
+	if !assert.NoError(t, err) {
+		return
+	}
 
-		c := &configurer{configFolderPath: tmpDir}
-		uc, err := c.readUserConfig()
-		if assert.NoError(t, err) {
-			assert.Equal(t, testDeviceID1, uc.GetDeviceID())
-		}
+	assert.True(t, result1.VPNNeedsReconfiguring)
+	assert.NotEmpty(t, result1.IPSToExcludeFromVPN)
 
-		result2, err := Configure(tmpDir, testDeviceID2)
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.False(t, result2.VPNNeedsReconfiguring)
-		ips1 := strings.Split(result1.IPSToExcludeFromVPN, ",")
-		ips2 := strings.Split(result2.IPSToExcludeFromVPN, ",")
-		sort.Strings(ips1)
-		sort.Strings(ips2)
+	c := &configurer{configFolderPath: tmpDir}
+	uc, err := c.readUserConfig()
+	if assert.NoError(t, err) {
+		assert.Equal(t, testDeviceID1, uc.GetDeviceID())
+	}
+
+	result2, err := Configure(tmpDir, testDeviceID2)
+	if !assert.NoError(t, err) {
+		return
+	}
+	ips1 := strings.Split(result1.IPSToExcludeFromVPN, ",")
+	ips2 := strings.Split(result2.IPSToExcludeFromVPN, ",")
+	sort.Strings(ips1)
+	sort.Strings(ips2)
+	if result2.VPNNeedsReconfiguring {
+		assert.NotEqual(t, ips1, ips2)
+	} else {
 		assert.Equal(t, ips1, ips2)
+	}
 
-		uc, err = c.readUserConfig()
-		if assert.NoError(t, err) {
-			assert.Equal(t, testDeviceID2, uc.GetDeviceID())
-		}
-	*/
+	uc, err = c.readUserConfig()
+	if assert.NoError(t, err) {
+		assert.Equal(t, testDeviceID2, uc.GetDeviceID())
+	}
 }


### PR DESCRIPTION
The test was failing because the cloud config no longer matches the embedded config and the test had been written on the assumption that it did match. The test is now happy either way, it just makes sure that the response is internally consistent (i.e. if no reconfig necessary, excluded ips should be the same, else they should be different).