### PR TITLE
Allow specifying client country when using runAsUser

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -20,6 +20,7 @@ const (
 	PingHeader                          = "X-Lantern-Ping"
 	PlatformHeader                      = "X-Lantern-Platform"
 	ProxyDialTimeoutHeader              = "X-Lantern-Dial-Timeout"
+	ClientCountryHeader                 = "X-Lantern-Client-Country"
 )
 
 // AddCommonHeadersWithOptions sets standard http headers on a request bound

--- a/hitProxy.py
+++ b/hitProxy.py
@@ -22,7 +22,7 @@ def create_tmpdir():
     else:
         return tempfile.mkdtemp(prefix="lantern")
 
-def run_with_configdir(configdir, sticky=True, headless=False):
+def run_with_configdir(configdir, sticky=True, headless=False, country=""):
     path = ""
     if on_windows:
         path = "./lantern-cli.exe"
@@ -40,6 +40,8 @@ def run_with_configdir(configdir, sticky=True, headless=False):
         args = args + ["-stickyconfig"]
     if headless:
         args = args + ["-headless"]
+    if country:
+        args = args + ["-force-config-country", country]
     subprocess.call(args)
 
 

--- a/main/flags.go
+++ b/main/flags.go
@@ -24,6 +24,7 @@ var (
 	pprofAddr             = flag.String("pprofaddr", "", "pprof address to listen on, not activate pprof if empty")
 	forceProxyAddr        = flag.String("force-proxy-addr", "", "if specified, force chained proxying to use this address instead of the configured one, assuming an HTTP proxy")
 	forceAuthToken        = flag.String("force-auth-token", "", "if specified, force chained proxying to use this auth token instead of the configured one")
+	forceConfigCountry    = flag.String("force-config-country", "", "if specified, force config fetches to pretend they're coming from this 2 letter country-code")
 	readableconfig        = flag.Bool("readableconfig", false, "if specified, disables obfuscation of the config yaml so that it remains human readable")
 	bordaReportInterval   = flag.Duration("borda-report-interval", 15*time.Minute, "How frequently to report errors to borda. Set to 0 to disable reporting.")
 	bordaSamplePercentage = flag.Float64("borda-sample-percentage", 0.01, "The percentage of activity to report to Borda (0.01 = 1%)")

--- a/main/main.go
+++ b/main/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/getlantern/i18n"
 
 	"github.com/getlantern/flashlight/chained"
+	"github.com/getlantern/flashlight/config"
 	"github.com/getlantern/flashlight/desktop"
 
 	"github.com/mitchellh/panicwrap"
@@ -84,6 +85,11 @@ func main() {
 
 	if *forceProxyAddr != "" {
 		chained.ForceProxy(*forceProxyAddr, *forceAuthToken)
+	}
+
+	if *forceConfigCountry != "" {
+		log.Debugf("Will force config fetches to pretend client country is: %v", *forceConfigCountry)
+		config.ForceCountry(*forceConfigCountry)
 	}
 
 	if a.ShowUI {

--- a/runAsUser.py
+++ b/runAsUser.py
@@ -15,10 +15,14 @@ import hitProxy
 r = ru.redis_shell
 
 if len(sys.argv) < 2:
-    print "Usage: %s user-id" % sys.argv[0]
+    print "Usage: %s user-id [country]" % sys.argv[0]
     sys.exit(1)
 
 user_id = sys.argv[1]
+country = ""
+if len(sys.argv) > 2:
+    country = sys.argv[2]
+
 token = r.hget('user->token', user_id)
 
 if not token:
@@ -35,6 +39,6 @@ try:
             'proxyAll': 'true',
         }, encoding='utf-8', allow_unicode=True, default_flow_style=False)
         f.write(cfg)
-    hitProxy.run_with_configdir(configdir, sticky=False, headless=True)
+    hitProxy.run_with_configdir(configdir, sticky=False, headless=True, country=country)
 finally:
     shutil.rmtree(configdir)


### PR DESCRIPTION
This allows seeing a specific country's proxy configuration even if not running in that country.

Depends on https://github.com/getlantern/config-server/pull/168