### PR TITLE
Use local cache to avoid redis failure with VPN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rediscache.json
 flashlight
 flashlight.ex?
 autoupdate-prod.go

--- a/runAsUser.py
+++ b/runAsUser.py
@@ -27,7 +27,7 @@ if len(sys.argv) > 2:
 
 # Since we'll often be running via a VPN with this script, use a little local cache to avoid
 # redis calls that may fail.
-user_file = 'redis_data.txt'
+user_file = '.rediscache.json'
 token = None
 if not path.isfile(user_file):
     data = {}


### PR DESCRIPTION
Pulling this in from another branch -- been using it locally forever, and it works well.

Basically when running via a VPN the redis call often fails. This allows caches successful redis lookups locally to avoid that.