### PR TITLE
bumps zip file size limit to ensure all log files are sent

### DIFF
--- a/ios/report_issue.go
+++ b/ios/report_issue.go
@@ -43,7 +43,11 @@ func ReportIssue(appVersion string, deviceModel string, iosVersion string, email
 		},
 	}
 	b := &bytes.Buffer{}
-	err := logging.ZipLogFilesFrom(b, 5*1024*1024, map[string]string{"app": appLogsDir, "tunnel": tunnelLogsDir})
+	// 5MB is logfile size limit, and we have:
+	// two targets (app/netEx) with their own logs
+	// each target has 6 ios log files and 6 go log files
+	// for a total of 24 files * 5MB 
+	err := logging.ZipLogFilesFrom(b, 5*1024*1024*24, map[string]string{"app": appLogsDir, "tunnel": tunnelLogsDir})
 	if err != nil {
 		log.Errorf("Unable to zip log files: %v", err)
 	} else {


### PR DESCRIPTION
Ran into an issue on iOS where submitted logs were mysteriously incomplete. This is because the "file size limit" was misconstrued as _size per file_, whereas its actually _total file size_.  

Happy to remove / shorten / lengthen comment per request.