### PR TITLE
Don't use staging config server

### DIFF
--- a/config/initializer.go
+++ b/config/initializer.go
@@ -219,11 +219,12 @@ func checkOverrides(flags map[string]interface{},
 // getProxyURL returns the proxy URL to use depending on whether or not
 // we're in staging.
 func getProxyURL(staging bool) string {
-	if staging {
-		log.Debug("Configuring for staging")
-		return proxiesStagingURL
-	}
-	log.Debugf("Not configuring for staging.")
+	// Staging config server is currently not working, ignore it
+	// if staging {
+	// log.Debug("Configuring for staging")
+	// return proxiesStagingURL
+	// }
+	log.Debug("Will obtain proxies.yaml from production service")
 	return proxiesURL
 }
 
@@ -231,9 +232,9 @@ func getProxyURL(staging bool) string {
 // we're in staging.
 func getGlobalURL(staging bool) string {
 	if staging {
-		log.Debug("Configuring for staging")
+		log.Debug("Will obtain global.yaml from staging service")
 		return globalStagingURL
 	}
-	log.Debugf("Not configuring for staging.")
+	log.Debug("Will obtain global.yaml from production service")
 	return globalURL
 }

--- a/pro/proxy.go
+++ b/pro/proxy.go
@@ -34,7 +34,7 @@ func (pt *proxyTransport) RoundTrip(req *http.Request) (resp *http.Response, err
 				"Connection":                   {"keep-alive"},
 				"Access-Control-Allow-Methods": {"GET, POST"},
 				"Access-Control-Allow-Headers": {req.Header.Get("Access-Control-Request-Headers")},
-				"Via": {"Lantern Client"},
+				"Via":                          {"Lantern Client"},
 			},
 			Body: ioutil.NopCloser(strings.NewReader("preflight complete")),
 		}


### PR DESCRIPTION
The staging config server isn't set up correctly, but staging is still useful for testing pro server functionality like purchasing. With the staging config server being broken, Lantern is pretty unusable when running against staging. This change at least allows us to test purchasing and basic pro server functionality.