### PR TITLE
Allow forcing config country on Android

### DIFF
--- a/android/android.go
+++ b/android/android.go
@@ -76,6 +76,7 @@ type Session interface {
 	Locale() string
 	Code() string
 	GetCountryCode() string
+	GetForcedCountryCode() string
 	GetDNSServer() string
 	Provider() string
 	AppVersion() string
@@ -315,6 +316,11 @@ func run(configDir, locale string,
 	httpProxyAddr := fmt.Sprintf("%s:%d",
 		settings.GetHttpProxyHost(),
 		settings.GetHttpProxyPort())
+
+	forcedCountryCode := session.GetForcedCountryCode()
+	if forcedCountryCode != "" {
+		config.ForceCountry(forcedCountryCode)
+	}
 
 	flashlight.Run(httpProxyAddr, // listen for HTTP on provided address
 		"127.0.0.1:0",                // listen for SOCKS on random address

--- a/android/android_test.go
+++ b/android/android_test.go
@@ -41,6 +41,7 @@ func (c testSession) ConfigUpdate(bool)             {}
 func (c testSession) ShowSurvey(survey string)      {}
 func (c testSession) GetUserID() int64              { return 0 }
 func (c testSession) GetToken() string              { return "" }
+func (c testSession) GetForcedCountryCode() string  { return "" }
 func (c testSession) GetDNSServer() string          { return "8.8.8.8" }
 func (c testSession) SetStaging(bool)               {}
 func (c testSession) SetCountry(string)             {}

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -25,6 +26,8 @@ var (
 // ForceCountry forces config fetches to pretend client is running in the
 // given countryCode (e.g. 'cn')
 func ForceCountry(countryCode string) {
+	countryCode = strings.ToLower(countryCode)
+	log.Debugf("Forcing config country to %v", countryCode)
 	forceCountry.Store(countryCode)
 }
 


### PR DESCRIPTION
Mimics the `--force-config-country` flag from desktop. Useful for testing proxy assignment.