### PR TITLE
Send platform header in proxiedconn

### DIFF
--- a/client/proxied_conn.go
+++ b/client/proxied_conn.go
@@ -15,6 +15,7 @@ type proxiedConn struct {
 func (conn *proxiedConn) OnRequest(req *http.Request) {
 	// consumed and removed by http-proxy-lantern/versioncheck
 	req.Header.Set(common.VersionHeader, common.Version)
+	req.Header.Set(common.PlatformHeader, common.Platform)
 
 	// By default the proxy at this point has swapped any Proxy-Connection headers for Connection.
 	// In this chained proxy case, we want to swap it back.


### PR DESCRIPTION
This might help make sure that we have a platform for all traffic reported on proxies.