### PR TITLE
Migrate replica API to camelCase

### DIFF
--- a/desktop/replica/object.go
+++ b/desktop/replica/object.go
@@ -11,11 +11,11 @@ import (
 // This is supposed to mirror parts of SearchResultItem in replica-search.
 // https://github.com/getlantern/replica-search/blob/a9975d98e2b40d7c8087dc27d434cc4bb13299fe/src/server.rs#L9-L24
 type objectInfo struct {
-	Link         string    `json:"replica_link"`
-	FileSize     int64     `json:"file_size"`
-	MimeTypes    []string  `json:"mime_types"`
-	LastModified time.Time `json:"last_modified"`
-	DisplayName  string    `json:"display_name"`
+	Link         string    `json:"replicaLink"`
+	FileSize     int64     `json:"fileSize"`
+	MimeTypes    []string  `json:"mimeTypes"`
+	LastModified time.Time `json:"lastModified"`
+	DisplayName  string    `json:"displayName"`
 }
 
 // Inits from a BitTorrent metainfo that must contain a valid info.


### PR DESCRIPTION
Along with https://github.com/getlantern/replica-search/pull/7 use camelCase for replica APIs