### PR TITLE
Add duplicate and missing field checks to config checker

### DIFF
--- a/config/configchecker/main.go
+++ b/config/configchecker/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/getlantern/flashlight/chained"
 	"github.com/getlantern/flashlight/config"
 	"github.com/getlantern/flashlight/domainrouting"
-	"github.com/getlantern/yaml"
+	"github.com/go-yaml/yaml"
 )
 
 func main() {
@@ -84,7 +84,7 @@ func readRemote(target string) ([]byte, error) {
 
 func parseProxies(bytes []byte) {
 	cfg := make(map[string]*chained.ChainedServerInfo)
-	err := yaml.Unmarshal(bytes, cfg)
+	err := yaml.UnmarshalStrict(bytes, cfg)
 	if err != nil {
 		fail("Unable to parse proxies config: %v", err)
 	}
@@ -100,7 +100,7 @@ func parseProxies(bytes []byte) {
 
 func parseGlobal(bytes []byte) {
 	cfg := &config.Global{}
-	err := yaml.Unmarshal(bytes, cfg)
+	err := yaml.UnmarshalStrict(bytes, cfg)
 	if err != nil {
 		fail("Unable to parse global config: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/getlantern/winsvc v0.0.0-20160824205134-8bb3a5dbcc1d // indirect
 	github.com/getlantern/yaml v0.0.0-20190801163808-0c9bb1ebf426
 	github.com/getsentry/sentry-go v0.5.1
+	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/gorilla/websocket v1.4.0
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,8 @@ github.com/go-redis/redis v6.15.2+incompatible h1:9SpNVG76gr6InJGxoZ6IuuxaCOQwDA
 github.com/go-redis/redis v6.15.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
+github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=


### PR DESCRIPTION
Tested against config served to me when running Lantern.  I also tried adding duplicate fields and confirmed that this causes the checker to spit out an error.