### PR TITLE
Get UI server from channel

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -153,11 +153,9 @@ func (app *App) exitOnFatal(err error) {
 }
 
 func (app *App) uiServer() *ui.Server {
-	select {
-	case server := <-app.uiServerCh:
-		app.uiServerCh <- server
-		return server
-	}
+	server := <-app.uiServerCh
+	app.uiServerCh <- server
+	return server
 }
 
 // Run starts the app. It will block until the app exits.


### PR DESCRIPTION
This fixes https://github.com/getlantern/lantern-internal/issues/3650 along with any similar bugs that can occur due to the ui server not being initialized until `beforeStart`, which is after things like the config may have already been fetched.

I played around with more extreme refactorings to more carefully order things at startup, but this certainly seems like the simplest change.