### PR TITLE
Use more unique fingerprints in an attempt to prevent sentry from grouping distinct panics with the same top level message

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -85,6 +85,18 @@ func main() {
 		sentry.Init(sentry.ClientOptions{
 			Dsn:     desktop.SENTRY_DSN,
 			Release: common.Version,
+			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+				// An attempt at keeping sentry from grouping distinct panics with the same top level message
+				// see https://github.com/getlantern/lantern-internal/issues/3651
+				// and https://docs.sentry.io/data-management/event-grouping/sdk-fingerprinting/?platform=go
+				fingerprint := event.Message
+				messageLines := strings.Split(event.Message, "\n")
+				if len(messageLines) > 5 {
+					fingerprint = strings.Join([]string{messageLines[0], messageLines[1], messageLines[4], messageLines[5]}, "\n")
+				}
+				event.Fingerprint = []string{"{{ default }}", fingerprint}
+				return event
+			},
 		})
 
 		sentry.ConfigureScope(func(scope *sentry.Scope) {


### PR DESCRIPTION
Addresses https://github.com/getlantern/lantern-internal/issues/3651

Running this locally I'm seeing the correct behavior. Remember that if you're testing locally, you need to build the binary with a VERSION set, and it cannot be running headless.


Thanks!