### PR TITLE
Truncate the message sent to sentry to max allowable chars

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -132,13 +132,6 @@ func (app *App) loadSettings() *Settings {
 	return loadSettingsFrom(common.Version, common.RevisionDate, common.BuildDate, path, app.chrome)
 }
 
-func truncateString(s string, maxLength int) string {
-	if maxLength < len(s) {
-		return s[:maxLength]
-	}
-	return s
-}
-
 // LogPanicAndExit logs a panic and then exits the application. This function
 // is only used in the panicwrap parent process.
 func (app *App) LogPanicAndExit(msg string) {
@@ -147,7 +140,7 @@ func (app *App) LogPanicAndExit(msg string) {
 			scope.SetLevel(sentry.LevelFatal)
 		})
 
-		sentry.CaptureMessage(truncateString(msg, SENTRY_MAX_MESSAGE_CHARS))
+		sentry.CaptureMessage(msg)
 		if result := sentry.Flush(SENTRY_TIMEOUT); result == false {
 			log.Error("Flushing to Sentry timed out")
 		}

--- a/main/main.go
+++ b/main/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/getlantern/flashlight/config"
 	"github.com/getlantern/flashlight/desktop"
 	"github.com/getlantern/flashlight/logging"
+	"github.com/getlantern/flashlight/util"
 )
 
 var (
@@ -95,6 +96,11 @@ func main() {
 					fingerprint = strings.Join([]string{messageLines[0], messageLines[1], messageLines[4], messageLines[5]}, "\n")
 				}
 				event.Fingerprint = []string{"{{ default }}", fingerprint}
+
+				// sentry's sdk has a somewhat undocumented max message length
+				// after which it seems it will silently drop/fail to send messages
+				// https://github.com/getlantern/flashlight/pull/806
+				event.Message = util.TrimStringAsBytes(event.Message, desktop.SENTRY_MAX_MESSAGE_CHARS)
 				return event
 			},
 		})

--- a/util/string.go
+++ b/util/string.go
@@ -30,3 +30,10 @@ func TrimStringAsRunes(numChars uint, s string, trimFront bool) string {
 	}
 	return s
 }
+
+func TrimStringAsBytes(s string, maxLength int) string {
+	if maxLength < len(s) {
+		return s[:maxLength]
+	}
+	return s
+}


### PR DESCRIPTION
This attempts to address the issue described in https://github.com/getlantern/lantern-internal/issues/3620#issuecomment-616904350 where panics in the `anacrolix/torrent` library weren't getting reported to sentry.

From some random testing locally, it seems as though the stack trace we're attempting to sent to sentry is just too large and is causing the reporting to fail silently 😬 😬  (I think this is "documented" in https://github.com/getsentry/sentry-go/issues/169)

I chose 8k as the max number of characters from basically looking at successful sentry reports and looking at the point at which they were truncated (I think that sentry does some kind of truncation before storing on their end).

I was able to get a panic inside a goroutine in the `torrent` library to be reported after making the change:
https://sentry.io/organizations/getlantern/issues/1633600374/?project=2222244