### PR TITLE
Include exception 'value' in sentry fingerprint for correct grouping

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -83,36 +83,7 @@ func main() {
 	// This init needs to be called before the panicwrapper fork so that it has been
 	// defined in the parent process
 	if desktop.ShouldReportToSentry() {
-		sentry.Init(sentry.ClientOptions{
-			Dsn:     desktop.SENTRY_DSN,
-			Release: common.Version,
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-				// An attempt at keeping sentry from grouping distinct panics with the same top level message
-				// see https://github.com/getlantern/lantern-internal/issues/3651
-				// and https://docs.sentry.io/data-management/event-grouping/sdk-fingerprinting/?platform=go
-				fingerprint := event.Message
-				messageLines := strings.Split(event.Message, "\n")
-				if len(messageLines) > 5 {
-					fingerprint = strings.Join([]string{messageLines[0], messageLines[1], messageLines[4], messageLines[5]}, "\n")
-				}
-				event.Fingerprint = []string{"{{ default }}", fingerprint}
-
-				// sentry's sdk has a somewhat undocumented max message length
-				// after which it seems it will silently drop/fail to send messages
-				// https://github.com/getlantern/flashlight/pull/806
-				event.Message = util.TrimStringAsBytes(event.Message, desktop.SENTRY_MAX_MESSAGE_CHARS)
-				return event
-			},
-		})
-
-		sentry.ConfigureScope(func(scope *sentry.Scope) {
-			os_version, err := osversion.GetHumanReadable()
-			if err != nil {
-				log.Errorf("Unable to get os version: %v", err)
-			} else {
-				scope.SetTag("os_version", os_version)
-			}
-		})
+		initSentry()
 	}
 
 	// Disable panicwrap for cases either unnecessary or when the exit status
@@ -226,6 +197,48 @@ func i18nInit(a *desktop.App) {
 			a.SetLanguage(locale)
 		}
 	}
+}
+
+func initSentry() {
+	sentry.Init(sentry.ClientOptions{
+		Dsn:     desktop.SENTRY_DSN,
+		Release: common.Version,
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			// An attempt at keeping sentry from grouping distinct panics with the same top level message
+			// see https://github.com/getlantern/lantern-internal/issues/3651
+			// and https://docs.sentry.io/data-management/event-grouping/sdk-fingerprinting/?platform=go
+			messageFingerprint := ""
+			messageLines := strings.Split(event.Message, "\n")
+			if len(messageLines) > 5 {
+				messageFingerprint = strings.Join([]string{messageLines[0], messageLines[1], messageLines[4], messageLines[5]}, "\n")
+			}
+
+			exceptionFingerprint := ""
+			for _, exception := range event.Exception {
+				// Sentry is already correctly separating exceptions by stack traces, but inexplicably not
+				// by the exception.Value, so we have to add it here
+				// https://github.com/getlantern/lantern-internal/issues/3666
+				exceptionFingerprint += fmt.Sprintf("%v", exception.Value)
+			}
+
+			event.Fingerprint = []string{"{{ default }}", messageFingerprint, exceptionFingerprint}
+
+			// sentry's sdk has a somewhat undocumented max message length
+			// after which it seems it will silently drop/fail to send messages
+			// https://github.com/getlantern/flashlight/pull/806
+			event.Message = util.TrimStringAsBytes(event.Message, desktop.SENTRY_MAX_MESSAGE_CHARS)
+			return event
+		},
+	})
+
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		os_version, err := osversion.GetHumanReadable()
+		if err != nil {
+			log.Errorf("Unable to get os version: %v", err)
+		} else {
+			scope.SetTag("os_version", os_version)
+		}
+	})
 }
 
 func parseFlags() {


### PR DESCRIPTION
Attempts to address https://github.com/getlantern/lantern-internal/issues/3666

It looks like the only issue with sentry's grouping was that it wasn't using the error "message"/"value" in it's fingerprint algorithm. We can continue to use the "{{ default }}" fingerprint (which apparently includes the stack trace and the error type :upside_down_face: ) and just add the "value".

I've confirmed that this approach works with these QA errors:
https://sentry.io/organizations/getlantern/issues/1638288228/?project=2222244
https://sentry.io/organizations/getlantern/issues/1638289307/?project=2222244
https://sentry.io/organizations/getlantern/issues/1638290009/?project=2222244