### PR TITLE
Don't clear out configs when config is unchanged in cloud

### DIFF
--- a/ios/config.go
+++ b/ios/config.go
@@ -266,6 +266,11 @@ func (cf *configurer) updateFromWeb(name string, etag string, cfg interface{}, u
 		return false, err
 	}
 
+	if bytes == nil {
+		// config unchanged
+		return false, nil
+	}
+
 	cf.saveConfig(name, bytes)
 	cf.saveEtag(name, newETag)
 


### PR DESCRIPTION
For getlantern/lantern-internal#3702. Don't save empty configs when they were unchanged in the cloud.