### PR TITLE
Allow upload options

### DIFF
--- a/desktop/replica/server.go
+++ b/desktop/replica/server.go
@@ -141,8 +141,8 @@ func (me *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (me *httpHandler) handleUpload(rw http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		http.Error(rw, "expected POST", http.StatusMethodNotAllowed)
+	if r.Method != "POST" && r.Method != "OPTIONS" {
+		http.Error(rw, "expected POST or OPTIONS", http.StatusMethodNotAllowed)
 		return
 	}
 	w := ops.InitInstrumentedResponseWriter(rw, "replica_upload")


### PR DESCRIPTION
This fixes a CORS permissioning error we're hitting when running the UI server from a different port than Lantern is running on locally