### PR TITLE
Fix chromeextension test failure on linux

### DIFF
--- a/desktop/chromeextension_test.go
+++ b/desktop/chromeextension_test.go
@@ -23,7 +23,7 @@ func TestChromeExtension(t *testing.T) {
 
 	basePath, err = e.osExtensionBasePath("linux")
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(basePath, "chromium"))
+	assert.True(t, strings.Contains(basePath, "chromium") || strings.Contains(basePath, "google-chrome"))
 
 	_, err = e.osExtensionBasePath("eurequrq9ur")
 	assert.Error(t, err)


### PR DESCRIPTION
This test fails on linux if there's a `google-chrome` directory present in the user's home config directory.

I've just adjusted it slightly so it passes here :shrug: 