### PR TITLE
Removed unused replica.go

### DIFF
--- a/common/replica.go
+++ b/common/replica.go
@@ -1,9 +1,0 @@
-package common
-
-import (
-	"strings"
-)
-
-func ReplicaEnabled() bool {
-	return strings.Contains(Version, "replica")
-}


### PR DESCRIPTION
For getlantern/lantern-internal#4013.

This isn't actually needed for fixing the ticket, but I noticed some unused code that we might as well remove.