### PR TITLE
Fix wrong search term in replica analytics reporting

### DIFF
--- a/desktop/replica/server.go
+++ b/desktop/replica/server.go
@@ -319,7 +319,7 @@ func (me *HttpHandler) handleSearch(rw http.ResponseWriter, r *http.Request) {
 	w := ops.InitInstrumentedResponseWriter(rw, "replica_search")
 	defer w.Finish()
 
-	searchTerm := r.URL.Query().Get("q")
+	searchTerm := r.URL.Query().Get("s")
 
 	w.Op.Set("search_term", searchTerm)
 	me.gaSession.EventWithLabel("replica", "search", searchTerm)


### PR DESCRIPTION
Fixes a small bug I made in https://github.com/getlantern/flashlight/pull/843

The search query property is `s`, not `q` :facepalm: 