### PR TITLE
Don't propagate panics from stopping Go tun2socks implementation

### DIFF
--- a/android/tun_linux.go
+++ b/android/tun_linux.go
@@ -82,6 +82,13 @@ func Tun2Socks(fd int, socksAddr, dnsAddr, dnsGrabAddr string, mtu int) error {
 
 // StopTun2Socks stops the current tun device.
 func StopTun2Socks() {
+	defer func() {
+		p := recover()
+		if p != nil {
+			log.Errorf("Panic while stopping: %v", p)
+		}
+	}()
+
 	currentDeviceMx.Lock()
 	dev := currentDevice
 	ipp := currentIPP


### PR DESCRIPTION
For getlantern/lantern-internal#4126.

As best as I can tell, many of the crashes seem to happen after stopping the VPN. I haven't been able to reproduce myself, but this might help and will at least give us a log of the panic (if it is indeed in Go).