### PR TITLE
Report default browser as part of op

### DIFF
--- a/browsers/browsers_darwin.go
+++ b/browsers/browsers_darwin.go
@@ -99,6 +99,9 @@ func SystemDefault(ctx context.Context) (Browser, error) {
 	op.Set("os", "darwin")
 	b, err := systemDefault(ctx)
 	op.FailIf(err)
+	if b != Unknown {
+		op.Set("browser", b.String())
+	}
 	op.End()
 	return b, err
 }

--- a/browsers/browsers_windows.go
+++ b/browsers/browsers_windows.go
@@ -132,6 +132,9 @@ func SystemDefault(ctx context.Context) (Browser, error) {
 	op.Set("os", "windows")
 	b, err := systemDefault(ctx)
 	op.FailIf(err)
+	if b != Unknown {
+		op.Set("browser", b.String())
+	}
 	op.End()
 	return b, err
 }


### PR DESCRIPTION
This should have been part of https://github.com/getlantern/flashlight/pull/862, but got left out somehow.  We'll want this so that we can start gathering some data on which browsers are popular amongst our users.