### PR TITLE
Register debug/conntrack under /replica path to avoid panic on duplic…

### DIFF
--- a/cmd/replica-standalone-ui-backend/main.go
+++ b/cmd/replica-standalone-ui-backend/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/anacrolix/log"
 	"github.com/anacrolix/tagflag"
+	"github.com/getlantern/appdir"
 	"github.com/getlantern/flashlight/analytics"
 	"github.com/getlantern/flashlight/common"
 	desktopReplica "github.com/getlantern/flashlight/desktop/replica"
@@ -30,6 +31,7 @@ func main() {
 func mainCode(flags flags) int {
 	uc := common.NewUserConfigData("replica-standalone", 0, "replica-standalone-token", nil, "en-US")
 	handler, exitFunc, err := desktopReplica.NewHTTPHandler(
+		appdir.General("ReplicaStandalone"),
 		uc,
 		&replica.Client{
 			HttpClient: http.DefaultClient,

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -478,6 +478,7 @@ func (app *App) checkForReplica(features map[string]bool) {
 		app.startReplica.Do(func() {
 			log.Debug("Starting replica from app")
 			replicaHandler, exitFunc, err := desktopReplica.NewHTTPHandler(
+				app.ConfigDir,
 				getSettings(),
 				&replica.Client{
 					HttpClient: &http.Client{

--- a/desktop/replica/server.go
+++ b/desktop/replica/server.go
@@ -47,7 +47,7 @@ type HttpHandler struct {
 }
 
 // NewHTTPHandler creates a new http.Handler for calls to replica.
-func NewHTTPHandler(uc common.UserConfig, replicaClient *replica.Client, gaSession analytics.Session) (_ *HttpHandler, exitFunc func(), err error) {
+func NewHTTPHandler(configDir string, uc common.UserConfig, replicaClient *replica.Client, gaSession analytics.Session) (_ *HttpHandler, exitFunc func(), err error) {
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		err = fmt.Errorf("accessing the user cache dir: %w", err)
@@ -56,7 +56,7 @@ func NewHTTPHandler(uc common.UserConfig, replicaClient *replica.Client, gaSessi
 
 	logger := golog.LoggerFor("replica.server")
 	const replicaDirElem = "replica"
-	replicaConfigDir, configErr := common.InConfigDir("", replicaDirElem)
+	replicaConfigDir, configErr := common.InConfigDir(configDir, replicaDirElem)
 	if configErr != nil {
 		err = configErr
 		return
@@ -80,11 +80,6 @@ func NewHTTPHandler(uc common.UserConfig, replicaClient *replica.Client, gaSessi
 	// don't want to overload their networks, so ensure the default connection tracking
 	// behaviour.
 	//cfg.ConnTracker = conntrack.NewInstance()
-	// Helps debug connection tracking, for best configuring DHT and other limits.
-	http.HandleFunc("/debug/conntrack", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		cfg.ConnTracker.PrintStatus(w)
-	})
 	torrentClient, err := torrent.NewClient(cfg)
 	if err != nil {
 		logger.Errorf("Error creating client: %v", err)
@@ -126,6 +121,11 @@ func NewHTTPHandler(uc common.UserConfig, replicaClient *replica.Client, gaSessi
 		for _, ds := range torrentClient.DhtServers() {
 			ds.WriteStatus(w)
 		}
+	})
+	// Helps debug connection tracking, for best configuring DHT and other limits.
+	handler.mux.HandleFunc("/debug/conntrack", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		cfg.ConnTracker.PrintStatus(w)
 	})
 	// TODO(anacrolix): Actually not much of Confluence is used now, probably none of the
 	// routes, so this might go away soon.


### PR DESCRIPTION
…ate registrations during integration test, also fixes application of configDir path in when creating replica config

This fixes test failures like this one - https://app.circleci.com/pipelines/github/getlantern/lantern-build/820/workflows/53e2ccda-9c88-4cc0-9a43-e765cf7872e1/jobs/786