### PR TITLE
Fixing errors while running logging_test

### DIFF
--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -107,8 +109,13 @@ func countMessages(b []byte) int {
 }
 
 func TestCloseAndInit(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "logging_test")
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer os.RemoveAll(tmpDir)
 	for i := 0; i < 10; i++ {
-		EnableFileLogging("")
+		EnableFileLogging(tmpDir)
 		Close()
 	}
 }


### PR DESCRIPTION
I noticed some errors like the below when running this test. This takes care of that.

```
Oct 08 18:28:14.646 - 0m0s ERROR flashlight.logging: logging.go:77 Unable to create logdir at : mkdir : no such file or directory [error=Unable to create logdir at %s: %s error_location=github.com/getlantern/flashlight/logging.RotatedLogsUnder (logging.go:48) error_op=mkdir error_text=Unable to create logdir at : mkdir : no such file or directory error_type=errors.Error]
ERROR flashlight.logging: logging.go:77   at github.com/getlantern/flashlight/logging.RotatedLogsUnder (logging.go:48)
ERROR flashlight.logging: logging.go:77   at github.com/getlantern/flashlight/logging.EnableFileLoggingWith (logging.go:85)
ERROR flashlight.logging: logging.go:77   at github.com/getlantern/flashlight/logging.EnableFileLogging (logging.go:75)
ERROR flashlight.logging: logging.go:77   at github.com/getlantern/flashlight/logging.TestCloseAndInit (logging_test.go:111)
ERROR flashlight.logging: logging.go:77   at testing.tRunner (testing.go:991)
ERROR flashlight.logging: logging.go:77   at runtime.goexit (asm_amd64.s:1373)
ERROR flashlight.logging: logging.go:77 Caused by: no such file or directory
```