### PR TITLE
Fix systray tooltip for lantern

### DIFF
--- a/desktop/systray.go
+++ b/desktop/systray.go
@@ -151,12 +151,13 @@ func refreshSystray(language string) {
 }
 
 func refreshMenuItems() {
-	systray.SetTooltip(i18n.T(translationAppName))
 	menu.upgrade.SetTitle(i18n.T("TRAY_UPGRADE_TO_PRO"))
 	if translationAppName == "BEAM" {
+		systray.SetTooltip(i18n.T(translationAppName))
 		menu.show.SetTitle(i18n.T("TRAY_SHOW", i18n.T(translationAppName)))
 		menu.quit.SetTitle(i18n.T("TRAY_QUIT", i18n.T(translationAppName)))
 	} else {
+		systray.SetTooltip(i18n.T("TRAY_LANTERN"))
 		menu.show.SetTitle(i18n.T("TRAY_SHOW_LANTERN"))
 		menu.quit.SetTitle(i18n.T("TRAY_QUIT"))
 	}


### PR DESCRIPTION
This fix for supporting old translations for lantern neglected to take the tooltip into account, so that's currently untranslated in live versions:

https://github.com/getlantern/flashlight/commit/eef33e3c0ba7e8f40d833274cad9e68380dfc7fb#diff-00166881c99bdddca4382bba524320713496364844b90b78f82a7e5d3d086c1d