### PR TITLE
Revert "Update anacrolix/torrent"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/anacrolix/go-libutp v1.0.3
 	github.com/anacrolix/log v0.7.1-0.20200604014615-c244de44fd2d
 	github.com/anacrolix/tagflag v1.1.1-0.20200411025953-9bb5209d56c2
-	github.com/anacrolix/torrent v1.18.0
+	github.com/anacrolix/torrent v1.17.1-0.20201006232255-d3daaaf75a46
 	github.com/blang/semver v0.0.0-20180723201105-3c1074078d32
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/dchest/siphash v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/anacrolix/torrent v1.11.0/go.mod h1:FwBai7SyOFlflvfEOaM88ag/jjcBWxTOq
 github.com/anacrolix/torrent v1.12.0/go.mod h1:vCkQMgViw2b6GbrTECqql4o2AZCCPujZaq3iEYnH0p4=
 github.com/anacrolix/torrent v1.15.0/go.mod h1:MFc6KcbpAyfwGqOyRkdarUK9QnKA/FkVg0usFk1OQxU=
 github.com/anacrolix/torrent v1.15.1-0.20200513043326-587f28d2fa30/go.mod h1:QlOfgrCz5kbvhOz8M58dUwHY5SfZ9VbIvReZ0z0MdIk=
-github.com/anacrolix/torrent v1.18.0 h1:QlyHeZ/cMmSzeP0E8PB9qNxca082js80gDWfF+prNmk=
-github.com/anacrolix/torrent v1.18.0/go.mod h1:JnoMhFCq4Hq5Q/A1BmXljEnjHzKWD2auPqbqf/xwFHA=
+github.com/anacrolix/torrent v1.17.1-0.20201006232255-d3daaaf75a46 h1:HSF+X5mUZXH+lQixv0b3HSs4/MUTzDaSF+ZXRXcqUy0=
+github.com/anacrolix/torrent v1.17.1-0.20201006232255-d3daaaf75a46/go.mod h1:XWo/fJN1oKgcjgxM+pUZpvalHfqHDs27BY5mBZjIQWo=
 github.com/anacrolix/upnp v0.1.1/go.mod h1:LXsbsp5h+WGN7YR+0A7iVXm5BL1LYryDev1zuJMWYQo=
 github.com/anacrolix/upnp v0.1.2-0.20200416075019-5e9378ed1425 h1:/Wi6l2ONI1FUFWN4cBwHOO90V4ylp4ud/eov6GUcVFk=
 github.com/anacrolix/upnp v0.1.2-0.20200416075019-5e9378ed1425/go.mod h1:Pz94W3kl8rf+wxH3IbCa9Sq+DTJr8OSbV2Q3/y51vYs=


### PR DESCRIPTION
Reverts getlantern/flashlight#932, as replica downloads are not working with this version. This appears to be the relevant log:

```
Oct 28 20:28:23.769 - 0m18s ERROR replica.server: server.go:410 error getting s3 key from magnet: parsing uuid: invalid UUID length: 22 [error=error getting s3 key from magnet: %v error_location=github.com/getlantern/flashlight/desktop/replica.(*HttpHandler).handleViewWith (server.go:410) error_text=error getting s3 key from magnet: parsing uuid: invalid UUID length: 22 error_type=errors.Error info_hash=903fcb7653c3bddb3725549de4c14e112fda1db7 inline_type=inline op=replica_view root_op=replica_view]
ERROR replica.server: server.go:410   at github.com/getlantern/flashlight/desktop/replica.(*HttpHandler).handleViewWith (server.go:410)
ERROR replica.server: server.go:410   at github.com/getlantern/flashlight/desktop/replica.(*HttpHandler).handleView (server.go:392)
ERROR replica.server: server.go:410   at github.com/getlantern/flashlight/desktop/replica.(*HttpHandler).wrapHandlerError.func1 (server.go:174)
ERROR replica.server: server.go:410   at net/http.HandlerFunc.ServeHTTP (server.go:2041)
ERROR replica.server: server.go:410   at net/http.(*ServeMux).ServeHTTP (server.go:2416)
ERROR replica.server: server.go:410   at github.com/getlantern/flashlight/desktop/replica.(*HttpHandler).ServeHTTP (server.go:154)
ERROR replica.server: server.go:410   at net/http.StripPrefix.func1 (server.go:2080)
```