### PR TITLE
Bug fix: system cert pool is not available on Windows

### DIFF
--- a/chained/tlsmasq_impl.go
+++ b/chained/tlsmasq_impl.go
@@ -99,10 +99,7 @@ func newTLSMasqImpl(configDir, name, addr string, s *ChainedServerInfo, uc commo
 	if err != nil {
 		return nil, errors.New("failed to parse proxy certificate: %v", err)
 	}
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, errors.New("failed to load system cert pool: %v", err)
-	}
+	pool := x509.NewCertPool()
 	pool.AddCert(cert)
 
 	pCfg, hellos := tlsConfigForProxy(configDir, ctx, name, s, uc)


### PR DESCRIPTION
This pool is used when hijacking tlsmasq connections. We only need the proxy cert anyway.

- [ ] Do the tests pass? Consistently?
Pending CI
- [ ] Did this change improve test coverage?
Stayed the same
- [ ] Has it been reviewed/approved by relevant teammates?
It's about to be
- [x] Can it be QA’d in staging or something like staging?
I QA'd it locally
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [x] Did you create new documentation? Is it accessible and in the right place?
- [x] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
N/A