### PR TITLE
Fix for HTTPS Everywhere test failure

### DIFF
--- a/client/handler_test.go
+++ b/client/handler_test.go
@@ -65,7 +65,7 @@ func TestRewriteHTTPSRedirectLoop(t *testing.T) {
 	httpsRewriteInterval = 100 * time.Millisecond
 	client := newClient()
 	client.rewriteToHTTPS = httpseverywhere.Eager()
-	testURL := "http://cdn2.shoptiques.net"
+	testURL := "http://www.hrc.org/"
 
 	req, _ := http.NewRequest("GET", testURL, nil)
 	resp, err := roundTrip(client, req)
@@ -73,13 +73,19 @@ func TestRewriteHTTPSRedirectLoop(t *testing.T) {
 		return
 	}
 	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode, "should rewrite to HTTPS at first")
+	assert.Equal(t, resp.Header.Get("Location"), "https://www.hrc.org/", "HTTPS Everywhere should redirect us.")
 
+	// The following is a bit brittle because it actually sends the request to the remote
+	// server, so we are beholden to what the server does. In this case, the server
+	// redirects to https://www.hrc.org:443/ as of this writing, which HTTPS Everywhere does
+	// not do, allowing us to differentiate between a local and a remote redirect.
 	req, _ = http.NewRequest("GET", testURL, nil)
 	resp, err = roundTrip(client, req)
 	if !assert.NoError(t, err) {
 		return
 	}
-	assert.NotEqual(t, http.StatusMovedPermanently, resp.StatusCode, "second request with same URL should not rewrite to avoid redirect loop")
+	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode, "second request should still hit the remote server and get redirected")
+	assert.Equal(t, resp.Header.Get("Location"), "https://www.hrc.org:443/", "second request with same URL should skip HTTPS Everywhere but still be redirected from the origin server")
 
 	time.Sleep(2 * httpsRewriteInterval)
 	req, _ = http.NewRequest("GET", testURL, nil)
@@ -88,6 +94,8 @@ func TestRewriteHTTPSRedirectLoop(t *testing.T) {
 		return
 	}
 	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode, "should rewrite to HTTPS some time later")
+	assert.Equal(t, resp.Header.Get("Location"), "https://www.hrc.org/", "HTTPS Everywhere should redirect us.")
+
 }
 
 // func TestAdSwap(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/getlantern/hellosplitter v0.1.0
 	github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55
 	github.com/getlantern/http-proxy-lantern/v2 v2.6.23
-	github.com/getlantern/httpseverywhere v0.0.0-20190322220559-c364cfbfeb57
+	github.com/getlantern/httpseverywhere v0.0.0-20201210200013-19ae11fc4eca
 	github.com/getlantern/i18n v0.0.0-20181205222232-2afc4f49bb1c
 	github.com/getlantern/idletiming v0.0.0-20200228204104-10036786eac5
 	github.com/getlantern/ipproxy v0.0.0-20201020142114-ed7e3a8d5d87

--- a/go.sum
+++ b/go.sum
@@ -359,8 +359,8 @@ github.com/getlantern/http-proxy v0.0.3-0.20200407205042-2382946d79e7 h1:pMuvepv
 github.com/getlantern/http-proxy v0.0.3-0.20200407205042-2382946d79e7/go.mod h1:w1u+Y1H2eEhJrUARfzPxVKMEHvvW96PcYujowufGV1s=
 github.com/getlantern/http-proxy-lantern/v2 v2.6.23 h1:mVjHkSht0wcJ5NKUdhvgWqtJsL5npEPorT/7Lgy8A70=
 github.com/getlantern/http-proxy-lantern/v2 v2.6.23/go.mod h1:xjmg6dahhQAPXJZnxJni3UJprwnD7NM3x0oT38Lq9/I=
-github.com/getlantern/httpseverywhere v0.0.0-20190322220559-c364cfbfeb57 h1:pKgsEq/uk8TX1hsavQ/dVa/4VDew8c+eHnMtgNAr0uE=
-github.com/getlantern/httpseverywhere v0.0.0-20190322220559-c364cfbfeb57/go.mod h1:4HB5d0IkyVGnvPSajTJQC5UkPub0t/toqULnaa0P3/4=
+github.com/getlantern/httpseverywhere v0.0.0-20201210200013-19ae11fc4eca h1:Of3VwFEfKbVnK5/VGy05XUbi6QvTs5Y2eLDfPv3O50E=
+github.com/getlantern/httpseverywhere v0.0.0-20201210200013-19ae11fc4eca/go.mod h1:TNC/xJFmctsSGyXqcnVWwCRCPD/4zGQP7yBVnLDRa/U=
 github.com/getlantern/i18n v0.0.0-20181205222232-2afc4f49bb1c h1:+JnT+Rwa/3rksc4Zi0u6fJ/WX+tPK58GtsrcXWVUU2U=
 github.com/getlantern/i18n v0.0.0-20181205222232-2afc4f49bb1c/go.mod h1:6yS3MFZmWDK0zxWXX0619QzZpqmCaHJ8P83Ee4QcTq0=
 github.com/getlantern/idletiming v0.0.0-20190529182719-d2fbc83372a5/go.mod h1:MGP8kEgZGgAhvHISt0hJGQgxg/VAqGdw3+kSZBnfC/4=


### PR DESCRIPTION
This fixes https://github.com/getlantern/lantern-internal/issues/4603 

The redirect test is failing because the host we're testing is no longer in DNS:

https://app.circleci.com/pipelines/github/getlantern/lantern-build/1027/workflows/3cb5ebd1-9179-451d-bab7-657dc8bd0ea5/jobs/959

