### PR TITLE
Fixed panic in threadLimitingTCPConn

### DIFF
--- a/ios/thread_limiting_conn_test.go
+++ b/ios/thread_limiting_conn_test.go
@@ -1,0 +1,54 @@
+package ios
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThreadLimitingConn(t *testing.T) {
+	const msg = "echo me"
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err == nil {
+				go func() {
+					io.Copy(conn, conn)
+				}()
+			}
+		}
+	}()
+
+	worker := newWorker(1)
+
+	readers := 100
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			_conn, err := net.Dial("tcp", l.Addr().String())
+			require.NoError(t, err)
+			conn := newThreadLimitingTCPConn(_conn, worker)
+			n, err := conn.Write([]byte(msg))
+			require.Equal(t, n, len(msg))
+			b := make([]byte, 1024)
+			n, err = conn.Read(b)
+			require.Equal(t, n, len(msg))
+			require.Equal(t, msg, string(b[:n]))
+
+			conn.Close()
+			_, err = conn.Write([]byte("extra"))
+			require.Equal(t, errWriteOnClosedConn, err)
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
This fixes panics on iOS like this:

```
Jan 06 02:00:08.053 - 16m36s ERROR ios: tcp.go:166 Panic while copying: runtime error: invalid memory address or nil pointer dereference
goroutine 7647 [running]:
runtime/debug.Stack(0x13037dc58, 0x104bc94a0, 0x104b53200)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x80
github.com/getlantern/netx.doCopy.func2(0x13037df28)
	/var/folders/j_/9dywssj524gf3100s4q9l48w0000gp/T/gomobile-work-786894550/pkg/mod/github.com/getlantern/netx@v0.0.0-20201229185957-3fadd2c8f5ba/copy.go:78 +0x40
panic(0x104bc94a0, 0x104b53200)
	/usr/local/go/src/runtime/panic.go:969 +0x114
github.com/getlantern/flashlight/ios.(*threadLimitingTCPConn).Write(0x13007f140, 0x130021800, 0x143, 0x5dc, 0x143, 0x0, 0x0)
	/Users/ox.to.a.cart/git/lantern-ios/src/github.com/getlantern/flashlight/ios/thread_limiting_conn.go:54 +0xbc
github.com/getlantern/netx.doCopy(0x104d99460, 0x13007f140, 0x104d99520, 0x13014c840, 0x130021800, 0x5dc, 0x5dc, 0x13030f740, 0x1300ccdb0, 0x13006c580, ...)
	/var/folders/j_/9dywssj524gf3100s4q9l48w0000gp/T/gomobile-work-786894550/pkg/mod/github.com/getlantern/netx@v0.0.0-20201229185957-3fadd2c8f5ba/copy.go:89 +0x2d4
created by github.com/getlantern/netx.BidiCopyWithOpts
	/var/folders/j_/9dywssj524gf3100s4q9l48w0000gp/T/gomobile-work-786894550/pkg/mod/github.com/getlantern/netx@v0.0.0-20201229185957-3fadd2c8f5ba/copy.go:61 +0x160
 [error=Panic while copying: %v
%v error_location=github.com/getlantern/netx.doCopy.func2 (copy.go:78) error_text=Panic while copying: runtime error: invalid memory address or nil pointer dereference
goroutine 7647 [running]:
runtime/debug.Stack(0x13037dc58, 0x104bc94a0, 0x104b53200)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x80
github.com/getlantern/netx.doCopy.func2(0x13037df28)
	/var/folders/j_/9dywssj524gf3100s4q9l48w0000gp/T/gomobile-work-786894550/pkg/mod/github.com/getlantern/netx@v0.0.0-20201229185957-3fadd2c8f5ba/copy.go:78 +0x40
panic(0x104bc94a0, 0x104b53200)
	/usr/local/go/src/runtime/panic.go:969 +0x114
github.com/getlantern/flashlight/ios.(*threadLimitingTCPConn).Write(0x13007f140, 0x130021800, 0x143, 0x5dc, 0x143, 0x0, 0x0)
	/Users/ox.to.a.cart/git/lantern-ios/src/github.com/getlantern/flashlight/ios/thread_limiting_conn.go:54 +0xbc
github.com/getlantern/netx.doCopy(0x104d99460, 0x13007f140, 0x104d99520, 0x13014c840, 0x130021800, 0x5dc, 0x5dc, 0x13030f740, 0x1300ccdb0, 0x13006c580, ...)
	/var/folders/j_/9dywssj524gf3100s4q9l48w0000gp/T/gomobile-work-786894550/pkg/mod/github.com/getlantern/netx@v0.0.0-20201229185957-3fadd2c8f5ba/copy.go:89 +0x2d4
created by github.com/getlantern/netx.BidiCopyWithOpts
	/var/folders/j_/9dywssj524gf3100s4q9l48w0000gp/T/gomobile-work-786894550/pkg/mod/github.com/getlantern/netx@v0.0.0-20201229185957-3fadd2c8f5ba/copy.go:61 +0x160
 error_type=errors.Error]
ERROR ios: tcp.go:166   at github.com/getlantern/netx.doCopy.func2 (copy.go:78)
ERROR ios: tcp.go:166   at runtime.gopanic (panic.go:969)
ERROR ios: tcp.go:166   at runtime.panicmem (panic.go:212)
ERROR ios: tcp.go:166   at runtime.sigpanic (signal_unix.go:695)
ERROR ios: tcp.go:166   at github.com/getlantern/flashlight/ios.(*threadLimitingTCPConn).Write (thread_limiting_conn.go:54)
ERROR ios: tcp.go:166   at github.com/getlantern/netx.doCopy (copy.go:89)
ERROR ios: tcp.go:166   at runtime.goexit (asm_arm64.s:1148)
ERROR ios: tcp.go:166 Caused by: runtime error: invalid memory address or nil pointer dereference
```

- [X] Do the tests pass? Consistently?
- [X] Did this change improve test coverage?