### PR TITLE
Send correct timezone to proxy servers on Android

### DIFF
--- a/android/android.go
+++ b/android/android.go
@@ -72,6 +72,7 @@ type Session interface {
 	ProxyAll() bool
 	BandwidthUpdate(int, int, int, int)
 	Locale() string
+	GetTimeZone() string
 	Code() string
 	GetCountryCode() string
 	GetForcedCountryCode() string
@@ -95,10 +96,11 @@ type userConfig struct {
 	session Session
 }
 
-func (uc *userConfig) GetDeviceID() string { return uc.session.GetDeviceID() }
-func (uc *userConfig) GetUserID() int64    { return uc.session.GetUserID() }
-func (uc *userConfig) GetToken() string    { return uc.session.GetToken() }
-func (uc *userConfig) GetLanguage() string { return uc.session.Locale() }
+func (uc *userConfig) GetDeviceID() string          { return uc.session.GetDeviceID() }
+func (uc *userConfig) GetUserID() int64             { return uc.session.GetUserID() }
+func (uc *userConfig) GetToken() string             { return uc.session.GetToken() }
+func (uc *userConfig) GetLanguage() string          { return uc.session.Locale() }
+func (uc *userConfig) GetTimeZone() (string, error) { return uc.session.GetTimeZone(), nil }
 func (uc *userConfig) GetInternalHeaders() map[string]string {
 	h := make(map[string]string)
 

--- a/android/android_test.go
+++ b/android/android_test.go
@@ -38,24 +38,25 @@ func (c testSettings) TimeoutMillis() int       { return 15000 }
 func (c testSettings) GetHttpProxyHost() string { return "127.0.0.1" }
 func (c testSettings) GetHttpProxyPort() int    { return 49128 }
 
-func (c testSession) AfterStart()                   {}
+func (c testSession) AfterStart()                        {}
 func (c testSession) BandwidthUpdate(int, int, int, int) {}
-func (c testSession) ConfigUpdate(bool)             {}
-func (c testSession) ShowSurvey(survey string)      {}
-func (c testSession) GetUserID() int64              { return 0 }
-func (c testSession) GetToken() string              { return "" }
-func (c testSession) GetForcedCountryCode() string  { return "" }
-func (c testSession) GetDNSServer() string          { return "8.8.8.8" }
-func (c testSession) SetStaging(bool)               {}
-func (c testSession) SetCountry(string)             {}
-func (c testSession) ProxyAll() bool                { return true }
-func (c testSession) GetDeviceID() string           { return "123456789" }
-func (c testSession) AccountId() string             { return "1234" }
-func (c testSession) Locale() string                { return "en-US" }
-func (c testSession) SetUserId(int64)               {}
-func (c testSession) SetToken(string)               {}
-func (c testSession) SetCode(string)                {}
-func (c testSession) IsProUser() bool               { return true }
+func (c testSession) ConfigUpdate(bool)                  {}
+func (c testSession) ShowSurvey(survey string)           {}
+func (c testSession) GetUserID() int64                   { return 0 }
+func (c testSession) GetToken() string                   { return "" }
+func (c testSession) GetForcedCountryCode() string       { return "" }
+func (c testSession) GetDNSServer() string               { return "8.8.8.8" }
+func (c testSession) SetStaging(bool)                    {}
+func (c testSession) SetCountry(string)                  {}
+func (c testSession) ProxyAll() bool                     { return true }
+func (c testSession) GetDeviceID() string                { return "123456789" }
+func (c testSession) AccountId() string                  { return "1234" }
+func (c testSession) Locale() string                     { return "en-US" }
+func (c testSession) GetTimeZone() string                { return "Americas/Chicago" }
+func (c testSession) SetUserId(int64)                    {}
+func (c testSession) SetToken(string)                    {}
+func (c testSession) SetCode(string)                     {}
+func (c testSession) IsProUser() bool                    { return true }
 
 func (c testSession) UpdateStats(string, string, string, int, int) {}
 

--- a/common/config.go
+++ b/common/config.go
@@ -2,6 +2,12 @@
 
 package common
 
+import (
+	"time"
+
+	"github.com/getlantern/timezone"
+)
+
 // an implementation of common.UserConfig
 type UserConfigData struct {
 	DeviceID string
@@ -11,10 +17,11 @@ type UserConfigData struct {
 	Headers  map[string]string
 }
 
-func (uc *UserConfigData) GetDeviceID() string { return uc.DeviceID }
-func (uc *UserConfigData) GetUserID() int64    { return uc.UserID }
-func (uc *UserConfigData) GetToken() string    { return uc.Token }
-func (uc *UserConfigData) GetLanguage() string { return uc.Language }
+func (uc *UserConfigData) GetDeviceID() string          { return uc.DeviceID }
+func (uc *UserConfigData) GetUserID() int64             { return uc.UserID }
+func (uc *UserConfigData) GetToken() string             { return uc.Token }
+func (uc *UserConfigData) GetLanguage() string          { return uc.Language }
+func (uc *UserConfigData) GetTimeZone() (string, error) { return timezone.IANANameForTime(time.Now()) }
 func (uc *UserConfigData) GetInternalHeaders() map[string]string {
 	h := make(map[string]string)
 	for k, v := range uc.Headers {

--- a/common/headers.go
+++ b/common/headers.go
@@ -4,9 +4,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/getlantern/timezone"
 )
 
 const (
@@ -50,7 +47,7 @@ func AddCommonHeadersWithOptions(uc UserConfig, req *http.Request, overwriteAuth
 	req.Header.Add(SupportedDataCaps, "monthly")
 	req.Header.Add(SupportedDataCaps, "weekly")
 	req.Header.Add(SupportedDataCaps, "daily")
-	tz, err := timezone.IANANameForTime(time.Now())
+	tz, err := uc.GetTimeZone()
 	if err != nil {
 		log.Debugf("omitting timezone header because: %v", err)
 	} else {

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -11,5 +11,6 @@ type AuthConfig interface {
 type UserConfig interface {
 	AuthConfig
 	GetLanguage() string
+	GetTimeZone() (string, error)
 	GetInternalHeaders() map[string]string
 }

--- a/desktop/settings.go
+++ b/desktop/settings.go
@@ -11,10 +11,12 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/getlantern/eventual"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/launcher"
+	"github.com/getlantern/timezone"
 	"github.com/getlantern/uuid"
 	"github.com/getlantern/yaml"
 
@@ -394,6 +396,10 @@ func (s *Settings) SetLanguage(language string) {
 // GetLanguage returns the user language
 func (s *Settings) GetLanguage() string {
 	return s.getString(SNLanguage)
+}
+
+func (s *Settings) GetTimeZone() (string, error) {
+	return timezone.IANANameForTime(time.Now())
 }
 
 // SetLocalHTTPToken sets the local HTTP token, stored on disk because we've

--- a/ios/ios.go
+++ b/ios/ios.go
@@ -287,6 +287,7 @@ func partialUserConfigFor(deviceID string) *UserConfig {
 }
 
 func userConfigFor(userID int, proToken, deviceID string) *UserConfig {
+	// TODO: plug in implementation of fetching timezone for iOS to work around https://github.com/golang/go/issues/20455
 	return &UserConfig{
 		UserConfigData: *common.NewUserConfigData(
 			deviceID,


### PR DESCRIPTION
Due to a [Go bug](https://github.com/golang/go/issues/20455), system times contain the wrong timezone. This works around that by having the client pass in the timezone that we use. 

- [ ] Do the tests pass? Consistently?