### PR TITLE
Updated to latest dnsgrab that ignores SVCB and HTTPS queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/getlantern/cmuxprivate v0.0.0-20200905032931-afb63438e40b
 	github.com/getlantern/common v1.1.1-0.20200824002646-ca4a48d3a74c
 	github.com/getlantern/detour v0.0.0-20200814023224-28e20f4ac2d1
-	github.com/getlantern/dnsgrab v0.0.0-20201210181937-c9d055f15acc
+	github.com/getlantern/dnsgrab v0.0.0-20210120195910-d879cb272122
 	github.com/getlantern/domains v0.0.0-20200402172102-34a8db1e0e83
 	github.com/getlantern/ema v0.0.0-20190620044903-5943d28f40e4
 	github.com/getlantern/enhttp v0.0.0-20190401024120-a974fa851e3c

--- a/go.sum
+++ b/go.sum
@@ -286,10 +286,10 @@ github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 h1:NRUJuo3v3WGC
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/detour v0.0.0-20200814023224-28e20f4ac2d1 h1:7Iij6/WnGBryEpBuhLEOwWFX61ubsx3ann4fRHKJTlY=
 github.com/getlantern/detour v0.0.0-20200814023224-28e20f4ac2d1/go.mod h1:5iIcBTk/mor1hyVGucgUKLnH8ucQ0Gk+gmHog7g7NIw=
-github.com/getlantern/dns v0.0.0-20170920204204-630ccc2c3041 h1:0+6PMeuySx1d4G6JZcThwbqgdXYRzlvKIUJWqndZ4Tw=
-github.com/getlantern/dns v0.0.0-20170920204204-630ccc2c3041/go.mod h1:CbTkjHHMyw9CPQKfTyYx2XldN/XJSmqTwHl3HLwvo2Y=
-github.com/getlantern/dnsgrab v0.0.0-20201210181937-c9d055f15acc h1:y7KkY3xuVvYIel+Yp7QkQ9MSlG13z2hXSyjGJvs+38w=
-github.com/getlantern/dnsgrab v0.0.0-20201210181937-c9d055f15acc/go.mod h1:9LRmxmPpIIEW0fxvNoarT3OKvDOdoiNMSZeXaQBhh8I=
+github.com/getlantern/dns v0.0.0-20210120185712-8d005533efa0 h1:8DQSmWtwBy8Z0Zr/kiRJRhBPQO4LMN0mziCJd+8edhw=
+github.com/getlantern/dns v0.0.0-20210120185712-8d005533efa0/go.mod h1:nd1wZuSxVB7DZVqZT1hCFkdWcMqbuO5XQSd+1Duk/fs=
+github.com/getlantern/dnsgrab v0.0.0-20210120195910-d879cb272122 h1:tjSrXo2ubPfqeREGdeWujsnGONC781Snfvpit/nAfyo=
+github.com/getlantern/dnsgrab v0.0.0-20210120195910-d879cb272122/go.mod h1:5GwF/pPObuqMzWoCQ26QDowRMysQ61Sa1Gbc/9mQUZM=
 github.com/getlantern/domains v0.0.0-20200402172102-34a8db1e0e83 h1:KUQkZaAOrpCdbtJWfL0WqaFoB5IxbQdchLUIq6+dG1Y=
 github.com/getlantern/domains v0.0.0-20200402172102-34a8db1e0e83/go.mod h1:au2O/xaJUN17QP5ndAXBS8tSp0P7G9WnitSvuO/k9k0=
 github.com/getlantern/elevate v0.0.0-20180207094634-c2e2e4901072/go.mod h1:T4VB2POK13lsPLFV98WJQrL7gAXYD9TyJxBU2P8c8p4=

--- a/ios/udp.go
+++ b/ios/udp.go
@@ -214,9 +214,14 @@ func (h *directUDPHandler) ReceiveTo(downstream core.UDPConn, data []byte, addr 
 }
 
 func (h *directUDPHandler) receiveDNS(downstream core.UDPConn, data []byte, addr *net.UDPAddr) error {
-	response, err := h.grabber.ProcessQuery(data)
+	response, numAnswers, err := h.grabber.ProcessQuery(data)
 	if err != nil {
 		return log.Errorf("Unable to process dns query: %v", err)
+	}
+
+	if numAnswers == 0 {
+		// nothing to write
+		return nil
 	}
 
 	// MEMORY_OPTIMIZATION - use a threadLimitingUDPConn to limit the number of goroutines that are writing to LWIP


### PR DESCRIPTION
For getlantern/lantern-ios#60

- [x] Do the tests pass? Consistently?