### PR TITLE
Pull DHT rate limiting fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	git.torproject.org/pluggable-transports/obfs4.git v0.0.0-20180421031126-89c21805c212
 	github.com/anacrolix/confluence v1.6.2-0.20201116033747-ba09085bd120
 	github.com/anacrolix/dht v1.0.1 // indirect
+	github.com/anacrolix/dht/v2 v2.8.0 // indirect
 	github.com/anacrolix/envpprof v1.1.1
 	github.com/anacrolix/go-libutp v1.0.4
 	github.com/anacrolix/log v0.7.1-0.20200604014615-c244de44fd2d

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/anacrolix/dht/v2 v2.6.1 h1:ItcXTeOMNDh3FXGg+O8CPGgteOkWZ7kE/alG1OJ3TX
 github.com/anacrolix/dht/v2 v2.6.1/go.mod h1:7jf6kAZRU7FFwyeLP3f4LVH8WglAHdMte1mGcq8HQAg=
 github.com/anacrolix/dht/v2 v2.7.1 h1:4y4Dl1CD6ctrSP61YcIbgES2rmFLbuxYRRYLrMSji4Y=
 github.com/anacrolix/dht/v2 v2.7.1/go.mod h1:RjeKbveVwjnaVj5os4y/NQwqEoDWHigo5rdge9MP52k=
+github.com/anacrolix/dht/v2 v2.8.0 h1:u7NpANhFfAb+TKOSqI08YJtH7mavPPXQ9ePJyuqkWR0=
+github.com/anacrolix/dht/v2 v2.8.0/go.mod h1:RjeKbveVwjnaVj5os4y/NQwqEoDWHigo5rdge9MP52k=
 github.com/anacrolix/envpprof v0.0.0-20180404065416-323002cec2fa/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.0.0/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.0.1/go.mod h1:My7T5oSqVfEn4MD4Meczkw/f5lSIndGAKu/0SM/rkf4=


### PR DESCRIPTION
Pull in fix from https://github.com/anacrolix/dht/commit/1cdc54068570d19c27fd041fa139b2b0730429be that was discovered while fixing https://github.com/anacrolix/dht/issues/34.

This would cause flashlight users to have a suboptimal experience using DHT (it would be much more conservative than it really needed to be).