### PR TITLE
Ensure Git LFS is present when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,12 @@ define build-tags
 	EXTRA_LDFLAGS=$$(echo $$EXTRA_LDFLAGS | xargs) && echo "Extra ldflags: $$EXTRA_LDFLAGS"
 endef
 
-.PHONY: lantern beam update-icons vendor
+.PHONY: lantern beam update-icons vendor git-lfs
+
+git-lfs:
+	@if [ "$(shell which git-lfs)" = "" ]; then \
+		echo "Missing Git LFS. See https://git-lfs.github.com" && exit 1; \
+	fi
 
 lantern: $(SOURCES)
 	@$(call build-tags) && \
@@ -90,11 +95,11 @@ beam-linux: $(SOURCES)
 	@$(call build-tags) && \
 	HEADLESS=true GOOS=linux GOARCH=amd64 BINARY_NAME=beam-linux BUILD_TAGS="$$BUILD_TAGS headless" make app
 
-app:
+app: | git-lfs
 	GO111MODULE=on GOPRIVATE="github.com/getlantern" CGO_ENABLED=1 go build $(BUILD_RACE) -v -o $(BINARY_NAME) -tags="$$BUILD_TAGS" -ldflags="$$EXTRA_LDFLAGS -s " github.com/getlantern/flashlight/main;
 
 # vendor installs vendored dependencies using go modules
-vendor:
+vendor: | git-lfs
 	GO111MODULE=on go mod vendor
 
 # test go-bindata dependency and update icons if up-to-date


### PR DESCRIPTION
Git LFS is required for this project as a result of https://github.com/getlantern/flashlight/pull/867.  A dependency which that PR pulled in, trafficlog-flashlight, includes some large-ish embedded binaries.

This PR adds a guard to the Makefile ensuring that Git LFS is present.  This should result in more easily parsable error messages - otherwise the error message looks like a checksum mismatch in a Go module.  More info on that here: https://github.com/getlantern/trafficlog-flashlight#git-lfs-and-go-modules.