### PR TITLE
Check enabled features inside features service

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -329,6 +329,7 @@ func (app *App) checkEnabledFeatures(enabledFeatures map[string]bool) {
 func (app *App) startFeaturesService(chans ...<-chan bool) {
 	if service, err := app.ws.Register("features", func(write func(interface{})) {
 		enabledFeatures := app.flashlight.EnabledFeatures()
+		app.checkEnabledFeatures(enabledFeatures)
 		write(enabledFeatures)
 	}); err != nil {
 		log.Errorf("Unable to serve enabled features to UI: %v", err)


### PR DESCRIPTION
Fixes an issue where we weren't checking for features enabled at build time inside the features service we register with the Websocket server