### PR TITLE
Upgrade all references to tlsdialer/v3

### DIFF
--- a/chained/tls_file_cache_test.go
+++ b/chained/tls_file_cache_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/getlantern/tlsdialer"
+	"github.com/getlantern/tlsdialer/v3"
 	"github.com/getlantern/tlsresumption"
 	tls "github.com/refraction-networking/utls"
 	"github.com/stretchr/testify/assert"

--- a/chained/wss_impl.go
+++ b/chained/wss_impl.go
@@ -15,7 +15,7 @@ import (
 	"github.com/getlantern/fronted"
 	"github.com/getlantern/netx"
 	"github.com/getlantern/tinywss"
-	"github.com/getlantern/tlsdialer"
+	"github.com/getlantern/tlsdialer/v3"
 	tls "github.com/refraction-networking/utls"
 )
 

--- a/genconfig/genconfig.go
+++ b/genconfig/genconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/getlantern/fronted"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/keyman"
-	"github.com/getlantern/tlsdialer"
+	"github.com/getlantern/tlsdialer/v3"
 	"github.com/getlantern/yaml"
 
 	"github.com/getlantern/flashlight/balancer"

--- a/go.mod
+++ b/go.mod
@@ -87,8 +87,7 @@ require (
 	github.com/getlantern/timezone v0.0.0-20210104163318-083eaadcecbd
 	github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7
 	github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4
-	github.com/getlantern/tlsdialer v0.0.0-20200205115148-9bde2ed72c94
-	github.com/getlantern/tlsdialer/v3 v3.0.1-0.20200819212748-a098113dd9f3
+	github.com/getlantern/tlsdialer/v3 v3.0.1
 	github.com/getlantern/tlsmasq v0.4.2
 	github.com/getlantern/tlsresumption v0.0.0-20200205020452-74fc6ea4e074
 	github.com/getlantern/tlsutil v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -670,11 +670,9 @@ github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7 h1:wVcJbQS7pf4h
 github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7/go.mod h1:ZLyPOKtNWU4vWnAiRiNQ7hbfLMqCEuj1DgQWBtHp7tQ=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4 h1:73U3J4msGw3cXeKtCEbY7hbOdD6aX8gJv8BOu+VagF8=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4/go.mod h1:f8WmDYKFOaC5/y0d3GWl6UKf1ZbSlIoMzkuC8x7pUhg=
-github.com/getlantern/tlsdialer v0.0.0-20200205115148-9bde2ed72c94 h1:kX5zTm9JqEGerfvjwVlzDrVOav6PAgHGW3TpdFhkpKI=
-github.com/getlantern/tlsdialer v0.0.0-20200205115148-9bde2ed72c94/go.mod h1:yTOVvHTvYlXJo8jSSOV+kuv/tya5i0eIILe8jjsPHe8=
 github.com/getlantern/tlsdialer/v3 v3.0.0/go.mod h1:nznxIhqehmOa3l8YAeEiXoVL57LtRVdbzafVCqIL+PM=
-github.com/getlantern/tlsdialer/v3 v3.0.1-0.20200819212748-a098113dd9f3 h1:amkTbS53qelVeBDju0L7avzRbhpoYURIFDAkPEHk18k=
-github.com/getlantern/tlsdialer/v3 v3.0.1-0.20200819212748-a098113dd9f3/go.mod h1:ZK1keXRsQsvmyCUCnVdmPOXH47OTlyEbSlGrV5C0urA=
+github.com/getlantern/tlsdialer/v3 v3.0.1 h1:nyq8Cq5gIWZ1iONwPuUwhHG4yKFXHfxItx+j0sIvdqo=
+github.com/getlantern/tlsdialer/v3 v3.0.1/go.mod h1:ZK1keXRsQsvmyCUCnVdmPOXH47OTlyEbSlGrV5C0urA=
 github.com/getlantern/tlsmasq v0.4.0 h1:eW0eY0pQl29+J89IZo6FpQYNcWUrb0s7LOX26ioAKBk=
 github.com/getlantern/tlsmasq v0.4.0/go.mod h1:vBAh5C8rn0KVspvSwuuNw2ATnM4fHxCwNm7ULH/ZXqQ=
 github.com/getlantern/tlsmasq v0.4.2 h1:Oc/UEQyiKh1FLIaBww9meVaClW5/YPTPYvrYjZxHvuo=


### PR DESCRIPTION
It appears that we were relying on commits from `tlsdialer` and `tlsdialer/v3` which were not in the `master` branch of that repo.  All non-master branches in `tlsdialer` have disappeared (guessing someone was just tidying up), so those commits have disappeared too.  The result is that this project does not build (unless you still have those commits locally).

This PR should fix this by (1) moving the tlsdialer/v3 dependency to a tag on the master branch and (2) updating all references from tlsdialer to tlsdialer/v3.