### PR TITLE
isAddressProxyable: Avoid .onion domains

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -754,6 +754,9 @@ func (client *Client) isAddressProxyable(addr string) error {
 			if strings.HasSuffix(host, ".local") {
 				return fmt.Errorf("%v ends in .local, considering private", host)
 			}
+			if strings.HasSuffix(host, ".onion") {
+				return fmt.Errorf("%v ends in .onion, considering private", host)
+			}
 		}
 		// assuming non-private
 		return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -169,6 +169,8 @@ func TestIsAddressProxyable(t *testing.T) {
 		"address should not be proxyable if it's a plain hostname")
 	assert.Error(t, client.isAddressProxyable("something.local:80"),
 		"address should not be proxyable if it ends in .local")
+	assert.Error(t, client.isAddressProxyable("something.onion:80"),
+		"address should not be proxyable if it ends in .onion")
 	assert.NoError(t, client.isAddressProxyable("anysite.com:80"),
 		"address should be proxyable if it's not an IP address, not a plain hostname and does not end in .local")
 }


### PR DESCRIPTION
They are private, and we cannot proxy them, I saw a few errors
regarding onion domains in logs, I assume some user has catastrophically
badly configured their browser, but we should at best be dropping them
before they go out for DNS resolution

WARNING - This template is public, do not include any sensitive information

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?