### PR TITLE
Add aggressive cache headers for replica files, objectInfo, and metadata

### DIFF
--- a/desktop/replica/server.go
+++ b/desktop/replica/server.go
@@ -549,6 +549,7 @@ func (me *HttpHandler) handleMetadata(category string) func(*ops.InstrumentedRes
 		if err != nil {
 			return err
 		}
+		rw.Header().Set("Cache-Control", "public, max-age=604800, immutable")
 		_, err = io.Copy(rw, metadata)
 		return err
 	}
@@ -681,6 +682,7 @@ func (me *HttpHandler) handleViewWith(rw *ops.InstrumentedResponseWriter, r *htt
 
 	torrentFile := t.Files()[selectOnly]
 	fileReader := torrentFile.NewReader()
+	rw.Header().Set("Cache-Control", "public, max-age=604800, immutable")
 	confluence.ServeTorrentReader(rw, r, fileReader, torrentFile.Path())
 	return nil
 }
@@ -703,7 +705,7 @@ func (me *HttpHandler) handleObjectInfo(rw *ops.InstrumentedResponseWriter, r *h
 		return err
 	}
 	date := time.Unix(mi.CreationDate, 0).Format(time.RFC3339Nano)
-	rw.Header().Set("Cache-Control", "immutable")
+	rw.Header().Set("Cache-Control", "public, max-age=604800, immutable")
 	return encodeJsonResponse(rw, map[string]interface{}{"creationDate": date})
 }
 


### PR DESCRIPTION
Resolves https://github.com/getlantern/flashlight/issues/1093. @anacrolix can we also have the browser cache the replica files themselves? I can't imagine why not, but that wasn't indicated in the issue.