### PR TITLE
Test fix: generate upstreams without spawning goroutines

### DIFF
--- a/chained/shadowsocks_impl_test.go
+++ b/chained/shadowsocks_impl_test.go
@@ -31,14 +31,8 @@ func TestGenerateUpstream(t *testing.T) {
 	}
 
 	runs := 10000
-	names := make(chan string, runs)
 	for i := 0; i < runs; i++ {
-		go func() {
-			names <- ng.generateUpstream()
-		}()
-	}
-	for i := 0; i < runs; i++ {
-		up := <-names
+		up := ng.generateUpstream()
 		host, _, err := net.SplitHostPort(up)
 		assert.Nil(t, err, "result address did not have a host and port")
 		assert.True(t, strings.HasSuffix(host, ".test"), "Unexpected suffix %s", up)


### PR DESCRIPTION
The race detector kills the program if more than 8192 concurrent goroutines are
spawned: https://github.com/golang/go/issues/23611

FWIW, this change actually speeds up the test as well.  On my machine, it takes about 40% as long as it formerly did.