### PR TITLE
Do not allow port 25/25-TLS to proxy in SOCKS mode

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -55,8 +55,6 @@ var (
 		80, 443,
 		// SSH for those who know how to configure it
 		22,
-		// SMTP and encrypted SMTP
-		25, 465,
 		// POP and encrypted POP
 		110, 995,
 		// IMAP and encrypted IMAP


### PR DESCRIPTION
This is too operationally risky. 

If it is not already being abused, this will be abused one day can cause our proxies to be null routed or the account with the provider to be put at risk.

Most cloud providers already filter this off for you anyway, so it's not like this is doing that much in the first place I suspect.