### PR TITLE
Improve appearance of lantern ads

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -154,6 +154,10 @@ func (ads PartnerAds) String(opts *config.GoogleSearchAdsOptions) string {
 	}
 	builder := strings.Builder{}
 
+	// Randomize the ads so we don't always show the same ones.
+	rand.Shuffle(len(ads), func(i, j int) {
+		ads[i], ads[j] = ads[j], ads[i]
+	})
 	for i, ad := range ads {
 		// Do not include more than a few ads.
 		if i >= 2 {


### PR DESCRIPTION
This should close https://github.com/getlantern/grants/issues/368 

It limits the number of ads to show to 2 and also ads the original base URL into the available data.