### PR TITLE
remove hardcoded cloudfront mappings and other unused bits.

### DIFF
--- a/chained/frontedtransport.go
+++ b/chained/frontedtransport.go
@@ -1,28 +1,9 @@
 package chained
 
 import (
-	"crypto/x509"
-	"fmt"
 	"net/http"
-	"path/filepath"
-	"time"
 
 	"github.com/getlantern/eventual"
-	"github.com/getlantern/fronted"
-	tls "github.com/refraction-networking/utls"
-)
-
-const (
-	cloudfrontID = "cloudfront"
-)
-
-var (
-	// special contexts for wss
-	frontingContexts = map[string]*fronted.FrontingContext{
-		cloudfrontID: fronted.NewFrontingContext(cloudfrontID),
-	}
-
-	frontingCertPool = eventual.NewValue()
 )
 
 type frontedTransport struct {
@@ -32,28 +13,4 @@ type frontedTransport struct {
 func (ft *frontedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt, _ := ft.rt.Get(eventual.Forever)
 	return rt.(http.RoundTripper).RoundTrip(req)
-}
-
-func ConfigureFronting(pool *x509.CertPool, providers map[string]*fronted.Provider, cacheFolder string) {
-	frontingCertPool.Set(pool)
-
-	// cloudfront only for wss.
-	pid := cloudfrontID
-	p := providers[pid]
-	if p != nil {
-		p = fronted.NewProvider(p.HostAliases, p.TestURL, p.Masquerades, p.Validator, []string{"*.cloudfront.net"})
-		ponly := map[string]*fronted.Provider{pid: p}
-		frontingContexts[pid].ConfigureWithHello(pool, ponly, pid, filepath.Join(cacheFolder, fmt.Sprintf("masquerade_cache.%s", pid)), tls.HelloChrome_Auto)
-	}
-}
-
-func GetFrontingContext(id string) *fronted.FrontingContext {
-	return frontingContexts[id]
-}
-
-func GetFrontingCertPool(timeout time.Duration) *x509.CertPool {
-	if v, ok := frontingCertPool.Get(timeout); ok {
-		return v.(*x509.CertPool)
-	}
-	return nil
 }

--- a/config/common_test.go
+++ b/config/common_test.go
@@ -119,11 +119,21 @@ pingsamplepercentage: 0
 reportissueemail: ""
 client:
   dumpheaders: false
+  fronted:
+    providers:
+      cloudfront:
+        hostaliases:
+          xyz.getiantem.org: xyz.cloudfront.net
+        masquerades: &id001
+        - domain: cloudfront.net
+          ipaddress: 54.182.1.120
+        testurl: http://zyx.cloudfront.net/ping
+        validator:
+          rejectstatus:
+          - 403
   masqueradesets:
     cloudflare: []
-    cloudfront:
-    - domain: ad1.awsstatic.com
-      ipaddress: 54.192.34.80
+    cloudfront: *id001
 adsettings: null
 proxiedsites:
   delta:

--- a/config/configchecker/main.go
+++ b/config/configchecker/main.go
@@ -126,7 +126,6 @@ func parseGlobal(bytes []byte) {
 	// Clear out high cardinality data before marshaling
 	cfg.ProxiedSites = nil
 	cfg.DomainRoutingRules = nil
-	cfg.Client.MasqueradeSets = nil
 	cfg.Client.Fronted.Providers = nil
 
 	out, err := yaml.Marshal(cfg)

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -75,7 +75,7 @@ func TestSubmitIssue(t *testing.T) {
 			return
 		}
 
-		fronted.Configure(pool, cfg.Client.FrontedProviders(), config.CloudfrontProviderID, filepath.Join(tempConfigDir, "masquerade_cache"))
+		fronted.Configure(pool, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID, filepath.Join(tempConfigDir, "masquerade_cache"))
 		SetHTTPClient(proxied.DirectThenFrontedClient(5 * time.Second))
 		defer SetHTTPClient(&http.Client{})
 

--- a/flashlight.go
+++ b/flashlight.go
@@ -446,8 +446,7 @@ func (f *Flashlight) applyClientConfig(cfg *config.Global) {
 	if err != nil {
 		log.Errorf("Unable to get trusted ca certs, not configuring fronted: %s", err)
 	} else if cfg.Client != nil && cfg.Client.Fronted != nil {
-		fronted.Configure(certs, cfg.Client.FrontedProviders(), config.CloudfrontProviderID, filepath.Join(f.configDir, "masquerade_cache"))
-		chained.ConfigureFronting(certs, cfg.Client.FrontedProviders(), f.configDir)
+		fronted.Configure(certs, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID, filepath.Join(f.configDir, "masquerade_cache"))
 	} else {
 		log.Errorf("Unable to configured fronted (no config)")
 	}

--- a/ios/config.go
+++ b/ios/config.go
@@ -236,7 +236,6 @@ func (cf *configurer) configureFronting(global *config.Global, timeout time.Dura
 	}
 
 	fronted.Configure(certs, global.Client.FrontedProviders(), "cloudfront", cf.fullPathTo("masquerade_cache"))
-	chained.ConfigureFronting(certs, global.Client.FrontedProviders(), cf.configFolderPath)
 	rt, ok := fronted.NewDirect(timeout)
 	if !ok {
 		return errors.New("Timed out waiting for fronting to finish configuring")


### PR DESCRIPTION
This removes some hardcoded cloudfront stuff.  This configuration information has been contained in global.yaml for a long time, so there is no need for it anymore.  Also cut out some related unused fronting bits from WSS and some complications that only applied to very old configurations.  The mapping information is moved to the genconfig package alongside the akamai mappings and other bits for generating configuration.

WARNING - This template is public, do not include any sensitive information

- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?