### PR TITLE
Fully reporting dial_for_balancer instead of balancer_dial

### DIFF
--- a/borda/borda.go
+++ b/borda/borda.go
@@ -39,7 +39,7 @@ var (
 		"proxy_rank",
 		"proxy_selection_stability",
 		"probe",
-		"balancer_dial",
+		"dial_for_balancer",
 		"proxy_dial",
 		"youtube_view",
 		"replica_upload",
@@ -49,7 +49,7 @@ var (
 
 	// LightweightOps are ops for which we record less than the full set of dimensions (e.g. omit error)
 	LightweightOps = []string{
-		"balancer_dial",
+		"dial_for_balancer",
 		"proxy_dial",
 		"youtube_view"}
 


### PR DESCRIPTION
For getlantern/lantern-internal#4975.

For some reason, we were using `balancer_dial` to detect CONNECT errors for blocking detection in borda. `balancer_dial` is the wrong op for this because it can encompass dials to multiple servers (until the first successful CONNECT) and it doesn't have metadata for any one particular server.

`dial_for_balancer` is the op that we want. The borda side was fixed [here](https://github.com/getlantern/lantern_aws/commit/f2209ff722edbc3c1bd81af2eb6aff3bd66b0a45). This commit makes sure that we get a good sized sample of data for this op to get more accurate blocking detection.

- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?