### PR TITLE
Implement scenic routing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -88,7 +88,7 @@ var (
 	// See http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
 	validHostnameRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 
-	errLanternOff = fmt.Errorf("Lantern is off")
+	errLanternOff = fmt.Errorf("lantern is off")
 
 	forceProxying int64
 )
@@ -381,7 +381,7 @@ func (client *Client) ListenAndServeHTTP(requestedAddr string, onListeningFn fun
 		requestedAddr = "127.0.0.1:0"
 		log.Debugf("About to listen at '%s'", requestedAddr)
 		if l, err = net.Listen("tcp", requestedAddr); err != nil {
-			return fmt.Errorf("Unable to listen: %q", err)
+			return fmt.Errorf("unable to listen: %q", err)
 		}
 	}
 	defer l.Close()
@@ -406,7 +406,7 @@ func (client *Client) ListenAndServeHTTP(requestedAddr string, onListeningFn fun
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
-			return fmt.Errorf("Unable to accept connection: %v", err)
+			return fmt.Errorf("unable to accept connection: %v", err)
 		}
 		go client.handle(conn)
 	}
@@ -421,7 +421,7 @@ func (client *Client) ListenAndServeSOCKS5(requestedAddr string) error {
 	var err error
 	var l net.Listener
 	if l, err = net.Listen("tcp", requestedAddr); err != nil {
-		return fmt.Errorf("Unable to listen: %q", err)
+		return fmt.Errorf("unable to listen: %q", err)
 	}
 	l = &optimisticListener{Listener: l}
 	defer l.Close()
@@ -453,7 +453,7 @@ func (client *Client) ListenAndServeSOCKS5(requestedAddr string) error {
 	}
 	server, err := socks5.New(conf)
 	if err != nil {
-		return fmt.Errorf("Unable to create SOCKS5 server: %v", err)
+		return fmt.Errorf("unable to create SOCKS5 server: %v", err)
 	}
 
 	log.Debugf("About to start SOCKS5 client proxy at %v", listenAddr)
@@ -607,17 +607,21 @@ func (client *Client) doDial(op *ops.Op, ctx context.Context, isCONNECT bool, ad
 	// It's roughly requestTimeout (20s) / 5 = 4s to leave enough time
 	// to try dialing via proxies. Not hardcode to 4s to avoid break test
 	// code which may have a shorter requestTimeout.
-	directTimeout := dl.Sub(time.Now()) / 5
+	directTimeout := time.Until(dl) / 5
 	cappedCTX, cancel := context.WithTimeout(ctx, directTimeout)
 	defer cancel()
 
 	dialDirectForDetour := func(ctx context.Context, network, addr string) (net.Conn, error) {
 		if client.useShortcut() {
-			if method, ip := client.shortcutMethod(cappedCTX, addr); method == shortcut.Direct {
+			method, ip := client.shortcutMethod(cappedCTX, addr)
+			switch method {
+			case shortcut.Direct:
 				// Arbitrarily have a larger timeout if the address is eligible for shortcut.
 				shortcutCTX, cancel := context.WithTimeout(ctx, directTimeout*2)
 				defer cancel()
 				return dialDirectForShortcut(shortcutCTX, network, addr, ip)
+			case shortcut.Proxy:
+				return dialProxied(ctx, "whatever", addr)
 			}
 		}
 		log.Tracef("Dialing %v directly for detour", addr)
@@ -637,12 +641,16 @@ func (client *Client) doDial(op *ops.Op, ctx context.Context, isCONNECT bool, ad
 		dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			var conn net.Conn
 			var err error
-			if method, ip := client.shortcutMethod(cappedCTX, addr); method == shortcut.Direct {
+			method, ip := client.shortcutMethod(cappedCTX, addr)
+			switch method {
+			case shortcut.Direct:
 				// Don't cap the context if the address is eligible for shortcut.
 				conn, err = dialDirectForShortcut(ctx, network, addr, ip)
 				if err == nil {
 					return conn, err
 				}
+			case shortcut.Proxy:
+				return dialProxied(ctx, "whatever", addr)
 			}
 			select {
 			case <-ctx.Done():
@@ -680,7 +688,7 @@ func (client *Client) isPortProxyable(port int) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("Port %d not proxyable", port)
+	return fmt.Errorf("port %d not proxyable", port)
 }
 
 // isAddressProxyable largely replicates the logic in the old PAC file
@@ -690,7 +698,7 @@ func (client *Client) isAddressProxyable(addr string) error {
 	}
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		return fmt.Errorf("Unable to split host and port for %v, considering private: %v", addr, err)
+		return fmt.Errorf("unable to split host and port for %v, considering private: %v", addr, err)
 	}
 
 	ip := net.ParseIP(host)
@@ -721,11 +729,11 @@ func (client *Client) isAddressProxyable(addr string) error {
 func (client *Client) portForAddress(addr string) (int, error) {
 	_, portString, err := net.SplitHostPort(addr)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to determine port for address %v: %v", addr, err)
+		return 0, fmt.Errorf("unable to determine port for address %v: %v", addr, err)
 	}
 	port, err := strconv.Atoi(portString)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to parse port %v for address %v: %v", addr, port, err)
+		return 0, fmt.Errorf("unable to parse port %v for address %v: %v", addr, port, err)
 	}
 	return port, nil
 }

--- a/client/optimistic_listener.go
+++ b/client/optimistic_listener.go
@@ -21,7 +21,6 @@ func (l *optimisticListener) Accept() (net.Conn, error) {
 	for {
 		conn, err := l.Listener.Accept()
 		if err == nil {
-			wait = minWait
 			return conn, nil
 		}
 		l.closedMx.Lock()


### PR DESCRIPTION
This takes advantage of the new changes in shortcut to tell lantern to proxy in certain cases, such as when a given address resolves to the known DNS poisoned blocking page in Iran.

Closes https://github.com/getlantern/lantern-internal/issues/5044