### PR TITLE
Be more aggressive about trying different ClientHellos for tlsmasq

### DIFF
--- a/chained/tlsmasq_impl.go
+++ b/chained/tlsmasq_impl.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/pem"
+	stderrors "errors"
 	"net"
 	"strings"
 	"sync"
@@ -165,15 +166,14 @@ func (h *utlsHandshaker) Handshake(conn net.Conn) (*ptlshs.HandshakeResult, erro
 	defer h.roller.updateTo(r)
 
 	isHelloErr := func(err error) bool {
-		if strings.Contains(err.Error(), "hello spec") {
-			// These errors are created below.
+		// We assume that everything other than timeouts or transient network errors might be
+		// related to the hello. This may be a little aggressive, but it's better that the client is
+		// willing to try other hellos, rather than get stuck in a loop on a bad one.
+		var netErr net.Error
+		if !stderrors.As(err, &netErr) {
 			return true
 		}
-		if strings.Contains(err.Error(), "tls: ") {
-			// A TLS-level error is likely related to a bad hello.
-			return true
-		}
-		return false
+		return !netErr.Temporary() && !netErr.Timeout()
 	}
 
 	currentHello := r.current()


### PR DESCRIPTION
We recently fixed a [HelloBrowser bug](https://github.com/getlantern/flashlight/pull/1160) which caused the client to send ClientHellos without an SNI.  I [discovered today](https://github.com/getlantern/tlsmasq/issues/34#issuecomment-991281128) that this causes some tlsmasq origins to respond to the ClientHello with an alert record.  I also noticed that the client did not, in this case, fall back to `HelloChrome_auto` or `HelloGolang`, as I expected.  I dug into this and decided to make the fallback logic a bit more aggressive.  I tested this with a modified client and confirmed that this would cause the client to fall back to one of the above hellos in the above scenario.