### PR TITLE
Use supplied appName instead of compiled-in appName

### DIFF
--- a/chained/chained_test.go
+++ b/chained/chained_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestUserConfig() *common.UserConfigData {
-	return common.NewUserConfigData("device", 1234, "protoken", nil, "en-US")
+	return common.NewUserConfigData(common.DefaultAppName, "device", 1234, "protoken", nil, "en-US")
 }
 
 type testImpl struct {

--- a/client/client.go
+++ b/client/client.go
@@ -49,8 +49,6 @@ import (
 var (
 	log = golog.LoggerFor("flashlight.client")
 
-	translationAppName = strings.ToUpper(common.AppName)
-
 	addr                = eventual.NewValue()
 	socksAddr           = eventual.NewValue()
 	proxiedCONNECTPorts = []int{
@@ -292,6 +290,8 @@ func (c *Client) MITMOptions() *mitm.Opts {
 				domains = append(domains, "*.google."+suffix)
 			}
 		}
+
+		translationAppName := strings.ToUpper(c.user.GetAppName())
 		return &mitm.Opts{
 			PKFile:             filepath.Join(c.configDir, "mitmkey.pem"),
 			CertFile:           filepath.Join(c.configDir, "mitmcert.pem"),

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -69,7 +69,7 @@ func init() {
 }
 
 func newTestUserConfig() *common.UserConfigData {
-	return common.NewUserConfigData("device", 1234, "protoken", nil, "en-US")
+	return common.NewUserConfigData(common.DefaultAppName, "device", 1234, "protoken", nil, "en-US")
 }
 
 func resetBalancer(client *Client, dialer func(network, addr string) (net.Conn, error)) {

--- a/common/beamconfig.go
+++ b/common/beamconfig.go
@@ -3,8 +3,7 @@
 package common
 
 const (
-	// AppName is the name of this specific app.
-	AppName = "Beam"
+	DefaultAppName = "Beam"
 
 	// ProAvailable specifies whether the user can purchase pro with this version.
 	ProAvailable = false

--- a/common/config.go
+++ b/common/config.go
@@ -10,6 +10,7 @@ import (
 
 // an implementation of common.UserConfig
 type UserConfigData struct {
+	AppName  string
 	DeviceID string
 	UserID   int64
 	Token    string
@@ -17,6 +18,7 @@ type UserConfigData struct {
 	Headers  map[string]string
 }
 
+func (uc *UserConfigData) GetAppName() string              { return uc.AppName }
 func (uc *UserConfigData) GetDeviceID() string             { return uc.DeviceID }
 func (uc *UserConfigData) GetUserID() int64                { return uc.UserID }
 func (uc *UserConfigData) GetToken() string                { return uc.Token }
@@ -34,8 +36,9 @@ func (uc *UserConfigData) GetInternalHeaders() map[string]string {
 var _ UserConfig = (*UserConfigData)(nil)
 
 // NewUserConfigData constucts a new UserConfigData (common.UserConfig) with the given options.
-func NewUserConfigData(deviceID string, userID int64, token string, headers map[string]string, lang string) *UserConfigData {
+func NewUserConfigData(appName string, deviceID string, userID int64, token string, headers map[string]string, lang string) *UserConfigData {
 	uc := &UserConfigData{
+		AppName:  appName,
 		DeviceID: deviceID,
 		UserID:   userID,
 		Token:    token,

--- a/common/headers.go
+++ b/common/headers.go
@@ -51,7 +51,7 @@ func AddCommonHeadersWithOptions(uc UserConfig, req *http.Request, overwriteAuth
 	}
 
 	req.Header.Set(PlatformHeader, Platform)
-	req.Header.Set(AppHeader, AppName)
+	req.Header.Set(AppHeader, uc.GetAppName())
 	req.Header.Add(SupportedDataCaps, "monthly")
 	req.Header.Add(SupportedDataCaps, "weekly")
 	req.Header.Add(SupportedDataCaps, "daily")

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -2,6 +2,7 @@ package common
 
 // AuthConfig retrieves any custom info for interacting with internal services.
 type AuthConfig interface {
+	GetAppName() string
 	GetDeviceID() string
 	GetUserID() int64
 	GetToken() string
@@ -19,6 +20,7 @@ type UserConfig interface {
 // NullAuthConfig is useful for testing
 type NullAuthConfig struct{}
 
+func (a NullAuthConfig) GetAppName() string              { return DefaultAppName }
 func (a NullAuthConfig) GetDeviceID() string             { return "" }
 func (a NullAuthConfig) GetUserID() int64                { return int64(10) }
 func (a NullAuthConfig) GetToken() string                { return "" }

--- a/common/lanternconfig.go
+++ b/common/lanternconfig.go
@@ -3,7 +3,8 @@
 package common
 
 const (
-	AppName = "Lantern"
+	// The default name for this app (used if no client-supplied name is passed at initialization)
+	DefaultAppName = "Lantern"
 
 	// ProAvailable specifies whether the user can purchase pro with this version.
 	ProAvailable = true

--- a/config/features.go
+++ b/config/features.go
@@ -269,7 +269,7 @@ func (g ClientGroup) Validate() error {
 
 //Includes checks if the ClientGroup includes the user, device and country
 //combination, assuming the group has been validated.
-func (g ClientGroup) Includes(userID int64, isPro bool, geoCountry string) bool {
+func (g ClientGroup) Includes(appName string, userID int64, isPro bool, geoCountry string) bool {
 	if g.UserCeil > 0 {
 		// Unknown user ID doesn't belong to any user range
 		if userID == 0 {
@@ -287,7 +287,7 @@ func (g ClientGroup) Includes(userID int64, isPro bool, geoCountry string) bool 
 	if g.ProOnly && !isPro {
 		return false
 	}
-	if g.Application != "" && strings.ToLower(g.Application) != strings.ToLower(common.AppName) {
+	if g.Application != "" && strings.ToLower(g.Application) != strings.ToLower(appName) {
 		return false
 	}
 	if g.VersionConstraints != "" {

--- a/config/features_test.go
+++ b/config/features_test.go
@@ -25,41 +25,41 @@ func TestValidate(t *testing.T) {
 }
 
 func TestIncludes(t *testing.T) {
-	assert.True(t, ClientGroup{}.Includes(0, true, "whatever"), "zero value should include all combinations")
-	assert.True(t, ClientGroup{}.Includes(111, false, "whatever"), "zero value should include all combinations")
-	assert.True(t, ClientGroup{UserCeil: 0.12}.Includes(111, false, "whatever"), "match user range")
-	assert.False(t, ClientGroup{UserCeil: 0.11}.Includes(111, false, "whatever"), "user range does not match")
-	assert.False(t, ClientGroup{UserCeil: 0.11}.Includes(0, false, "whatever"), "unknown user ID should not belong to any user range")
+	assert.True(t, ClientGroup{}.Includes(common.DefaultAppName, 0, true, "whatever"), "zero value should include all combinations")
+	assert.True(t, ClientGroup{}.Includes(common.DefaultAppName, 111, false, "whatever"), "zero value should include all combinations")
+	assert.True(t, ClientGroup{UserCeil: 0.12}.Includes(common.DefaultAppName, 111, false, "whatever"), "match user range")
+	assert.False(t, ClientGroup{UserCeil: 0.11}.Includes(common.DefaultAppName, 111, false, "whatever"), "user range does not match")
+	assert.False(t, ClientGroup{UserCeil: 0.11}.Includes(common.DefaultAppName, 0, false, "whatever"), "unknown user ID should not belong to any user range")
 
-	assert.True(t, ClientGroup{FreeOnly: true}.Includes(111, false, "whatever"), "user status met")
-	assert.False(t, ClientGroup{ProOnly: true}.Includes(111, false, "whatever"), "user status unmet")
-	assert.True(t, ClientGroup{ProOnly: true}.Includes(111, true, "whatever"), "user status met")
-	assert.False(t, ClientGroup{FreeOnly: true}.Includes(111, true, "whatever"), "user status unmet")
+	assert.True(t, ClientGroup{FreeOnly: true}.Includes(common.DefaultAppName, 111, false, "whatever"), "user status met")
+	assert.False(t, ClientGroup{ProOnly: true}.Includes(common.DefaultAppName, 111, false, "whatever"), "user status unmet")
+	assert.True(t, ClientGroup{ProOnly: true}.Includes(common.DefaultAppName, 111, true, "whatever"), "user status met")
+	assert.False(t, ClientGroup{FreeOnly: true}.Includes(common.DefaultAppName, 111, true, "whatever"), "user status unmet")
 
 	// The default AppName is "Default"
-	assert.True(t, ClientGroup{Application: common.AppName}.Includes(111, true, "whatever"), "application met, case insensitive")
-	assert.True(t, ClientGroup{Application: strings.ToUpper(common.AppName)}.Includes(111, true, "whatever"), "application met, case insensitive")
-	assert.False(t, ClientGroup{Application: "Beam"}.Includes(111, true, "whatever"), "application unmet, case insensitive")
-	assert.False(t, ClientGroup{Application: "beam"}.Includes(111, true, "whatever"), "application unmet, case insensitive")
+	assert.True(t, ClientGroup{Application: (common.DefaultAppName)}.Includes(common.DefaultAppName, 111, true, "whatever"), "application met, case insensitive")
+	assert.True(t, ClientGroup{Application: strings.ToUpper(common.DefaultAppName)}.Includes(common.DefaultAppName, 111, true, "whatever"), "application met, case insensitive")
+	assert.False(t, ClientGroup{Application: "Beam"}.Includes(common.DefaultAppName, 111, true, "whatever"), "application unmet, case insensitive")
+	assert.False(t, ClientGroup{Application: "beam"}.Includes(common.DefaultAppName, 111, true, "whatever"), "application unmet, case insensitive")
 
 	// The client version is 9999.99.99-dev when in development mode
-	assert.True(t, ClientGroup{VersionConstraints: "> 5.1.0"}.Includes(111, true, "whatever"), "version met")
-	assert.True(t, ClientGroup{VersionConstraints: "> 5.1.0 < 10000.0.0"}.Includes(111, true, "whatever"), "version met")
-	assert.False(t, ClientGroup{VersionConstraints: "< 5.1.0"}.Includes(111, true, "whatever"), "version unmet")
+	assert.True(t, ClientGroup{VersionConstraints: "> 5.1.0"}.Includes(common.DefaultAppName, 111, true, "whatever"), "version met")
+	assert.True(t, ClientGroup{VersionConstraints: "> 5.1.0 < 10000.0.0"}.Includes(common.DefaultAppName, 111, true, "whatever"), "version met")
+	assert.False(t, ClientGroup{VersionConstraints: "< 5.1.0"}.Includes(common.DefaultAppName, 111, true, "whatever"), "version unmet")
 
 	// Platforms tests are likely run
-	assert.True(t, ClientGroup{Platforms: "linux,darwin,windows"}.Includes(111, true, "whatever"), "platform met")
+	assert.True(t, ClientGroup{Platforms: "linux,darwin,windows"}.Includes(common.DefaultAppName, 111, true, "whatever"), "platform met")
 	// Platforms tests are unlikely run
-	assert.False(t, ClientGroup{Platforms: "ios,android"}.Includes(111, true, "whatever"), "platform unmet")
+	assert.False(t, ClientGroup{Platforms: "ios,android"}.Includes(common.DefaultAppName, 111, true, "whatever"), "platform unmet")
 
-	assert.True(t, ClientGroup{GeoCountries: "ir   , cn"}.Includes(111, true, "IR"), "country met")
-	assert.False(t, ClientGroup{GeoCountries: "us"}.Includes(111, true, "IR"), "country unmet")
+	assert.True(t, ClientGroup{GeoCountries: "ir   , cn"}.Includes(common.DefaultAppName, 111, true, "IR"), "country met")
+	assert.False(t, ClientGroup{GeoCountries: "us"}.Includes(common.DefaultAppName, 111, true, "IR"), "country unmet")
 
 	// Fraction calculation should be stable
 	g := ClientGroup{Fraction: 0.1}
 	hits := 0
 	for i := 0; i < 1000; i++ {
-		if g.Includes(111, true, "whatever") {
+		if g.Includes(common.DefaultAppName, 111, true, "whatever") {
 			hits++
 		}
 	}
@@ -85,10 +85,10 @@ featuresenabled:
 	if !assert.NoError(t, yaml.Unmarshal([]byte(yml), gl)) {
 		return
 	}
-	assert.True(t, gl.FeatureEnabled(FeatureReplica, 111, false, "au"), "met the first group")
-	assert.True(t, gl.FeatureEnabled(FeatureReplica, 111, true, ""), "met the second group")
-	assert.False(t, gl.FeatureEnabled(FeatureReplica, 211, false, "au"), "unmet both groups")
-	assert.False(t, gl.FeatureEnabled(FeatureReplica, 111, false, ""), "unmet both groups")
+	assert.True(t, gl.FeatureEnabled(FeatureReplica, common.DefaultAppName, 111, false, "au"), "met the first group")
+	assert.True(t, gl.FeatureEnabled(FeatureReplica, common.DefaultAppName, 111, true, ""), "met the second group")
+	assert.False(t, gl.FeatureEnabled(FeatureReplica, common.DefaultAppName, 211, false, "au"), "unmet both groups")
+	assert.False(t, gl.FeatureEnabled(FeatureReplica, common.DefaultAppName, 111, false, ""), "unmet both groups")
 }
 
 func TestUnmarshalFeatureOptions(t *testing.T) {

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newTestUserConfig() *common.UserConfigData {
-	return common.NewUserConfigData("deviceID", 10, "token", nil, "en-US")
+	return common.NewUserConfigData(common.DefaultAppName, "deviceID", 10, "token", nil, "en-US")
 }
 
 // TestFetcher actually fetches a config file over the network.

--- a/config/global.go
+++ b/config/global.go
@@ -69,23 +69,23 @@ func NewGlobal() *Global {
 }
 
 // FeatureEnabled checks if the feature is enabled given the client properties.
-func (cfg *Global) FeatureEnabled(feature string, userID int64, isPro bool,
+func (cfg *Global) FeatureEnabled(feature string, appName string, userID int64, isPro bool,
 	geoCountry string) bool {
-	enabled, _ := cfg.FeatureEnabledWithLabel(feature, userID, isPro, geoCountry)
+	enabled, _ := cfg.FeatureEnabledWithLabel(feature, appName, userID, isPro, geoCountry)
 	log.Tracef("Feature %v enabled for user %v in country %v?: %v", feature, userID, geoCountry, enabled)
 	return enabled
 }
 
 // FeatureEnabledWithLabel is the same as FeatureEnabled but also returns the
 // label of the first matched ClientGroup if the feature is enabled.
-func (cfg *Global) FeatureEnabledWithLabel(feature string, userID int64, isPro bool,
+func (cfg *Global) FeatureEnabledWithLabel(feature string, appName string, userID int64, isPro bool,
 	geoCountry string) (enabled bool, label string) {
 	groups, exists := cfg.FeaturesEnabled[feature]
 	if !exists {
 		return false, ""
 	}
 	for _, g := range groups {
-		if g.Includes(userID, isPro, geoCountry) {
+		if g.Includes(appName, userID, isPro, geoCountry) {
 			return true, g.Label
 		}
 	}

--- a/flashlight.go
+++ b/flashlight.go
@@ -176,6 +176,7 @@ func (f *Flashlight) calcFeature(global *config.Global, country, feature string)
 		return enabled
 	}
 	return global.FeatureEnabled(feature,
+		f.userConfig.GetAppName(),
 		f.userConfig.GetUserID(),
 		f.isPro(),
 		country)
@@ -281,7 +282,7 @@ func New(
 	adTrackUrl func() string,
 	eventWithLabel func(category, action, label string),
 ) (*Flashlight, error) {
-
+	log.Debugf("Running in app: %v", appName)
 	log.Debugf("Using configdir: %v", configDir)
 
 	if onProxiesUpdate == nil {

--- a/ios/config.go
+++ b/ios/config.go
@@ -117,6 +117,7 @@ func (cf *configurer) configure(userID int, proToken string, refreshProxies bool
 			log.Debugf("Successful geolookup: country %s", cf.uc.Country)
 			cf.uc.AllowProbes = !global.FeatureEnabled(
 				config.FeatureNoProbeProxies,
+				cf.uc.AppName,
 				int64(cf.uc.UserID),
 				cf.uc.Token != "",
 				cf.uc.Country)

--- a/ios/ios.go
+++ b/ios/ios.go
@@ -290,6 +290,7 @@ func userConfigFor(userID int, proToken, deviceID string) *UserConfig {
 	// TODO: plug in implementation of fetching timezone for iOS to work around https://github.com/golang/go/issues/20455
 	return &UserConfig{
 		UserConfigData: *common.NewUserConfigData(
+			"Lantern",
 			deviceID,
 			int64(userID),
 			proToken,

--- a/ios/logger/logger_darwin.go
+++ b/ios/logger/logger_darwin.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/getlantern/flashlight/logging"
 	"github.com/getlantern/golog"
@@ -31,9 +32,10 @@ func init() {
 // through lantern.log.5 already exist so that they are writeable from the Go
 // side.
 func ConfigureFileLogging(fullLogFilePath string) error {
-	logFileDirectory, _ := filepath.Split(fullLogFilePath)
+	logFileDirectory, filename := filepath.Split(fullLogFilePath)
+	appName := strings.Split(filename, ".")[0]
 	werr, wout := defaultLoggers()
-	return logging.EnableFileLoggingWith(werr, wout, logFileDirectory, 10, 10)
+	return logging.EnableFileLoggingWith(werr, wout, appName, logFileDirectory, 10, 10)
 }
 
 func defaultLoggers() (io.WriteCloser, io.WriteCloser) {

--- a/lanternsdk/lanternsdk.go
+++ b/lanternsdk/lanternsdk.go
@@ -104,7 +104,7 @@ func start(appName, configDir, deviceID string, proxyAll bool) error {
 		log.Debug("Stopping running Lantern")
 		runner.Stop()
 	} else {
-		logging.EnableFileLogging(configDir)
+		logging.EnableFileLogging(appName, configDir)
 		appdir.SetHomeDir(configDir)
 		increaseFilesLimit()
 
@@ -120,6 +120,7 @@ func start(appName, configDir, deviceID string, proxyAll bool) error {
 		}
 
 		userConfig := &common.UserConfigData{
+			AppName:  appName,
 			DeviceID: deviceID,
 			UserID:   0,       // not used for sdk clients
 			Token:    "",      // not used for sdk clients

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -17,7 +17,6 @@ import (
 	"github.com/getlantern/golog"
 	"github.com/getlantern/rotator"
 
-	"github.com/getlantern/flashlight/common"
 	"github.com/getlantern/flashlight/util"
 )
 
@@ -43,8 +42,8 @@ func init() {
 	resetLogs.Store(func() {})
 }
 
-// RotatedLogsUnder creates rotated file logger under logdir.
-func RotatedLogsUnder(logdir string) (io.WriteCloser, error) {
+// RotatedLogsUnder creates rotated file logger under logdir using the given appName
+func RotatedLogsUnder(appName, logdir string) (io.WriteCloser, error) {
 	actualLogDirMx.Lock()
 	actualLogDir = logdir
 	actualLogDirMx.Unlock()
@@ -58,7 +57,7 @@ func RotatedLogsUnder(logdir string) (io.WriteCloser, error) {
 		}
 	}
 
-	rotator := rotator.NewSizeRotator(filepath.Join(logdir, strings.ToLower(common.AppName)+".log"))
+	rotator := rotator.NewSizeRotator(filepath.Join(logdir, strings.ToLower(appName)+".log"))
 	// Set log files to 4 MB
 	rotator.RotationSize = 4 * 1024 * 1024
 	// Keep up to 5 log files
@@ -78,9 +77,9 @@ func Timestamped(w io.Writer) {
 }
 
 // EnableFileLogging configures golog to write to rotated files under the
-// logdir, in addition to standard outputs.
-func EnableFileLogging(logdir string) {
-	err := EnableFileLoggingWith(os.Stdout, os.Stderr, logdir, 100, 1000)
+// logdir for the given appName, in addition to standard outputs.
+func EnableFileLogging(appName, logdir string) {
+	err := EnableFileLoggingWith(os.Stdout, os.Stderr, appName, logdir, 100, 1000)
 	if err != nil {
 		log.Error(err)
 	}
@@ -88,9 +87,9 @@ func EnableFileLogging(logdir string) {
 
 // EnableFileLoggingWith is similar to EnableFileLogging but allows overriding
 // standard outputs and setting buffer depths for error and debug log channels.
-func EnableFileLoggingWith(werr io.WriteCloser, wout io.WriteCloser, logdir string, debugBufferDepth, errorBufferDepth int) error {
+func EnableFileLoggingWith(werr io.WriteCloser, wout io.WriteCloser, appName, logdir string, debugBufferDepth, errorBufferDepth int) error {
 	golog.SetPrepender(Timestamped)
-	rotator, err := RotatedLogsUnder(logdir)
+	rotator, err := RotatedLogsUnder(appName, logdir)
 	if err != nil {
 		return err
 	}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getlantern/flashlight/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -115,7 +116,7 @@ func TestCloseAndInit(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	for i := 0; i < 10; i++ {
-		EnableFileLogging(tmpDir)
+		EnableFileLogging(common.DefaultAppName, tmpDir)
 		Close()
 	}
 }

--- a/pro/client/client_test.go
+++ b/pro/client/client_test.go
@@ -16,7 +16,7 @@ func generateDeviceId() string {
 }
 
 func generateUser() *common.UserConfigData {
-	return common.NewUserConfigData(generateDeviceId(), 0, "", nil, "en-US")
+	return common.NewUserConfigData(common.DefaultAppName, generateDeviceId(), 0, "", nil, "en-US")
 }
 
 var (

--- a/pro/proxy_test.go
+++ b/pro/proxy_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/getlantern/flashlight/common"
-	"github.com/getlantern/flashlight/testutils"
 	"github.com/getlantern/flashlight/pro/client"
+	"github.com/getlantern/flashlight/testutils"
 )
 
 func TestProxy(t *testing.T) {
-	uc := common.NewUserConfigData("device", 0, "token", nil, "en-US")
+	uc := common.NewUserConfigData(common.DefaultAppName, "device", 0, "token", nil, "en-US")
 	m := &testutils.MockRoundTripper{Header: http.Header{}, Body: strings.NewReader("GOOD")}
 	httpClient = &http.Client{Transport: m}
 	l, err := net.Listen("tcp", "localhost:0")

--- a/pro/user_data.go
+++ b/pro/user_data.go
@@ -123,7 +123,7 @@ func newUserWithClient(uc common.UserConfig, hc *http.Client) (*client.User, err
 	logger.Debugf("Creating new user with device ID '%v'", deviceID)
 
 	// use deviceID, ignore userID, token
-	user := common.NewUserConfigData(deviceID, 0, "", uc.GetInternalHeaders(), uc.GetLanguage())
+	user := common.NewUserConfigData(uc.GetAppName(), deviceID, 0, "", uc.GetInternalHeaders(), uc.GetLanguage())
 	resp, err := client.NewClient(hc, PrepareProRequestWithOptions).UserCreate(user)
 	if err != nil {
 		return nil, err

--- a/pro/user_data_test.go
+++ b/pro/user_data_test.go
@@ -13,13 +13,13 @@ func TestUsers(t *testing.T) {
 	common.ForceStaging()
 
 	deviceID := "77777777"
-	u, err := newUserWithClient(common.NewUserConfigData(deviceID, 0, "", nil, "en-US"), nil)
+	u, err := newUserWithClient(common.NewUserConfigData(common.DefaultAppName, deviceID, 0, "", nil, "en-US"), nil)
 
 	assert.NoError(t, err, "Unexpected error")
 	assert.NotNil(t, u, "Should have gotten a user")
 	t.Logf("user: %+v", u)
 
-	uc := common.NewUserConfigData(deviceID, u.Auth.ID, u.Auth.Token, nil, "en-US")
+	uc := common.NewUserConfigData(common.DefaultAppName, deviceID, u.Auth.ID, u.Auth.Token, nil, "en-US")
 	u, err = fetchUserDataWithClient(uc, nil)
 	assert.NoError(t, err, "Unexpected error")
 	assert.NotNil(t, u, "Should have gotten a user")

--- a/proxied/proxied.go
+++ b/proxied/proxied.go
@@ -57,7 +57,7 @@ func success(resp *http.Response) bool {
 func changeUserAgent(req *http.Request) {
 	secondary := req.Header.Get("User-Agent")
 	ua := strings.TrimSpace(fmt.Sprintf("%s/%s (%s/%s) %s",
-		common.AppName, common.Version, common.Platform, runtime.GOARCH, secondary))
+		common.DefaultAppName, common.Version, common.Platform, runtime.GOARCH, secondary))
 	req.Header.Set("User-Agent", ua)
 }
 


### PR DESCRIPTION
For getlantern/android-lantern#628. Because the Lantern SDK is used by different applications without recompiling it for each application, we need to be able to pass in the application name rather than having it compiled in.

We already had the ability to pass in the app name, but it wasn't being respected throughout. This PR changes that so we always use the supplied appName rather than the one that's compiled in.

This will require some changes to `lantern-desktop` and `android-lantern` which I'll handle in separate PRs for those.

- [x] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?