### PR TITLE
add support for NamedDomainRoutingRules

### DIFF
--- a/config/configchecker/main.go
+++ b/config/configchecker/main.go
@@ -126,6 +126,7 @@ func parseGlobal(bytes []byte) {
 	// Clear out high cardinality data before marshaling
 	cfg.ProxiedSites = nil
 	cfg.DomainRoutingRules = nil
+	cfg.NamedDomainRoutingRules = nil
 	cfg.Client.Fronted.Providers = nil
 
 	out, err := yaml.Marshal(cfg)

--- a/config/generated/embedded-global.yaml
+++ b/config/generated/embedded-global.yaml
@@ -4068,6 +4068,14 @@ client:
   masqueradesets:
     cloudflare: []
     cloudfront: *id001
+nameddomainroutingrules:
+  google_play:
+    play.google.com: md
+    android.com: md
+    gvt1.com: md
+    gvt2.com: md
+    gvt3.com: md
+    android.clients.google.com: md
 domainroutingrules:
   .ir: d
   115.com: d

--- a/config/global.go
+++ b/config/global.go
@@ -39,6 +39,9 @@ type Global struct {
 	// DomainRoutingRules specifies routing rules for specific domains, such as forcing proxing, forcing direct dials, etc.
 	DomainRoutingRules domainrouting.Rules
 
+	// NamedDomainRoutingRules specifies routing rules for specific domains, grouped by name.
+	NamedDomainRoutingRules map[string]domainrouting.Rules
+
 	// TrustedCAs are trusted CAs for domain fronting domains only.
 	TrustedCAs []*fronted.CA
 

--- a/flashlight.go
+++ b/flashlight.go
@@ -150,6 +150,44 @@ func (f *Flashlight) EnabledFeatures() map[string]bool {
 	return featuresEnabled
 }
 
+// EnableNamedDomainRules adds named domain rules specified as arguments to the domainrouting rules table
+func (f *Flashlight) EnableNamedDomainRules(names ...string) {
+	f.mxGlobal.RLock()
+	global := f.global
+	f.mxGlobal.RUnlock()
+	if global == nil {
+		return
+	}
+	for _, name := range names {
+		if v, ok := global.NamedDomainRoutingRules[name]; !ok {
+			if err := domainrouting.AddRules(v); err != nil {
+				_ = log.Errorf("Unable to add named domain routing rules: %v", err)
+			}
+		} else {
+			log.Debugf("Named domain routing rule %s is not defined in global config", name)
+		}
+	}
+}
+
+// DisableNamedDomainRules removes named domain rules specified as arguments from the domainrouting rules table
+func (f *Flashlight) DisableNamedDomainRules(names ...string) {
+	f.mxGlobal.RLock()
+	global := f.global
+	f.mxGlobal.RUnlock()
+	if global == nil {
+		return
+	}
+	for _, name := range names {
+		if v, ok := global.NamedDomainRoutingRules[name]; !ok {
+			if err := domainrouting.RemoveRules(v); err != nil {
+				_ = log.Errorf("Unable to remove named domain routing rules: %v", err)
+			}
+		} else {
+			log.Debugf("Named domain routing rule %s is not defined in global config", name)
+		}
+	}
+}
+
 // FeatureEnabled returns true if the input feature is enabled for this flashlight instance. Feature
 // names are tracked in the config package.
 func (f *Flashlight) FeatureEnabled(feature string) bool {


### PR DESCRIPTION
Hey @oxtoacart! Happy new year!

As we've discussed, I've went with the 'named domain rules' approach, i.e. we have a section in global config that defines routing rules for groups of hosts.
In our case, we'll have a group called 'google_play' and it will have all the domains we want to skip.

The usage on the android side would be to call `f.EnableNamedDomainRules("google_play")` before starting the purchase and `f.DisableNamedDomainRules("google_play")`. What do you think?

P.S. this work is for https://github.com/getlantern/lantern-internal/issues/5108

thoughts?