### PR TITLE
Made Google Analytics and Matomo into features to use user_floor and …

### DIFF
--- a/config/features.go
+++ b/config/features.go
@@ -32,7 +32,8 @@ const (
 	FeatureGoogleSearchAds      = "googlesearchads"
 	FeatureYinbiWallet          = "yinbiwallet"
 	FeatureYinbi                = "yinbi"
-	FeatureAnalytics            = "analytics"
+	FeatureGoogleAnalytics      = "googleanalytics"
+	FeatureMatomo               = "matomo"
 )
 
 var (
@@ -46,29 +47,6 @@ var (
 // FeatureOptions is an interface implemented by all feature options
 type FeatureOptions interface {
 	fromMap(map[string]interface{}) error
-}
-
-type AnalyticsProvider struct {
-	SampleRate float32
-	Endpoint   string
-	Config     map[string]interface{}
-}
-
-// AnalyticsOptions is the configuration for analytics providers such as Google Analytics or Matomo.
-type AnalyticsOptions struct {
-	// Providers maps provider names to their sampling rates.
-	Providers map[string]*AnalyticsProvider
-}
-
-const GA = "ga"
-const MATOMO = "matomo"
-
-func (ao *AnalyticsOptions) fromMap(m map[string]interface{}) error {
-	return mapstructure.Decode(m, &ao)
-}
-
-func (ao *AnalyticsOptions) GetProvider(key string) *AnalyticsProvider {
-	return ao.Providers[key]
 }
 
 type ReplicaOptionsRoot struct {
@@ -321,9 +299,9 @@ func (g ClientGroup) Includes(appName string, userID int64, isPro bool, geoCount
 		if userID == 0 {
 			return false
 		}
-		percision := 1000.0
-		remainder := userID % int64(percision)
-		if remainder < int64(g.UserFloor*percision) || remainder >= int64(g.UserCeil*percision) {
+		precision := 1000.0
+		remainder := userID % int64(precision)
+		if remainder < int64(g.UserFloor*precision) || remainder >= int64(g.UserCeil*precision) {
 			return false
 		}
 	}

--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -117,6 +117,10 @@ featuresenabled:
       userfloor: 0
       userceil: 0.05
       geocountries: cn
+  matomo:
+    - label: matomo
+      userfloor: 0
+      userceil: 0.01
 featureoptions:
   trafficlog:
     capturebytes: 10485760


### PR DESCRIPTION
…user_ceil

For doing stuff like tracking purchase funnels in Android, it's better to segment by user than by random sampling events, that way we see all of the events for that user's funnel. Since we already have user segmentation available for features, I just made Matomo and GoogleAnalytics into features so that we can leverage that.

- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?