### PR TITLE
Use HTTP to make geolocation possible

### DIFF
--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -152,7 +152,7 @@ featureoptions:
     - https://s3.eu-central-1.amazonaws.com/getlantern-replica-frankfurt/
     - https://s3-eu-central-1.amazonaws.com/getlantern-replica-frankfurt/
     - https://d3mm73d1kmj7zd.cloudfront.net/
-    replicarustendpoint: &GlobalReplicaRust https://replica-search.lantern.io/
+    replicarustendpoint: &GlobalReplicaRust http://replica-search-aws.lantern.io/
     staticpeeraddrs: []
     trackers: &GlobalTrackers
     - https://tracker.gbitt.info:443/announce
@@ -167,7 +167,7 @@ featureoptions:
     # These are for compatibility with clients that don't load all options per-country.
     replicarustdefaultendpoint: *GlobalReplicaRust
     replicarustendpoints:
-      "RU": &FrankfurtReplicaRust https://replica-search-aws.lantern.io/
+      "RU": &FrankfurtReplicaRust http://replica-search-aws.lantern.io/
       "IR": *FrankfurtReplicaRust
 
     # Here follows options per-country


### PR DESCRIPTION
With HTTPS URLS, there is no way for proxies to add headers, such as X-Forwarded-For, and therefore no way to replica-rust to correctly geolocate clients.