### PR TITLE
Only run globalconfig workflow on pushes to devel

### DIFF
--- a/.github/workflows/globalconfig.yml
+++ b/.github/workflows/globalconfig.yml
@@ -2,6 +2,8 @@ name: Update Global Config
 
 on:
   push:
+    branches:
+      - devel
     paths:
       - 'embeddedconfig/global.yaml.tmpl'
   schedule:


### PR DESCRIPTION
I think this is firing for PRs that alter the path, but the workflow checks out devel anyway.