### PR TITLE
Only show error if embedded is required

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,9 @@ type options struct {
 	// embeddedData is the data for embedded configs, using tarfs.
 	embeddedData []byte
 
+	// whether or not embedded data is required.
+	embeddedRequired bool
+
 	// sleep the time to sleep between config fetches.
 	sleep func() time.Duration
 
@@ -192,7 +195,9 @@ func pipeConfig(opts *options) (stop func()) {
 // where there's some blocking event or bug preventing new configs from being fetched.
 func embeddedIsNewer(conf *config, opts *options) bool {
 	if opts.embeddedData == nil {
-		sentry.CaptureException(log.Errorf("no embedded config for %v", opts.name))
+		if opts.embeddedRequired {
+			sentry.CaptureException(log.Errorf("no embedded config for %v", opts.name))
+		}
 		return false
 	}
 

--- a/config/initializer.go
+++ b/config/initializer.go
@@ -107,15 +107,16 @@ func InitWithURLs(
 
 	// These are the options for fetching the per-user proxy config.
 	proxyOptions := &options{
-		saveDir:      configDir,
-		onSaveError:  onProxiesSaveError,
-		obfuscate:    obfuscate(flags),
-		name:         "proxies.yaml",
-		originURL:    proxyURL,
-		userConfig:   userConfig,
-		unmarshaler:  newProxiesUnmarshaler(),
-		dispatch:     proxiesDispatch,
-		embeddedData: embeddedconfig.Proxies,
+		saveDir:          configDir,
+		onSaveError:      onProxiesSaveError,
+		obfuscate:        obfuscate(flags),
+		name:             "proxies.yaml",
+		originURL:        proxyURL,
+		userConfig:       userConfig,
+		unmarshaler:      newProxiesUnmarshaler(),
+		dispatch:         proxiesDispatch,
+		embeddedData:     embeddedconfig.Proxies,
+		embeddedRequired: false,
 		sleep: func() time.Duration {
 			mx.RLock()
 			defer mx.RUnlock()
@@ -129,15 +130,16 @@ func InitWithURLs(
 
 	// These are the options for fetching the global config.
 	globalOptions := &options{
-		saveDir:      configDir,
-		onSaveError:  onGlobalSaveError,
-		obfuscate:    obfuscate(flags),
-		name:         "global.yaml",
-		originURL:    globalURL,
-		userConfig:   userConfig,
-		unmarshaler:  newGlobalUnmarshaler(flags),
-		dispatch:     globalDispatch,
-		embeddedData: embeddedconfig.Global,
+		saveDir:          configDir,
+		onSaveError:      onGlobalSaveError,
+		obfuscate:        obfuscate(flags),
+		name:             "global.yaml",
+		originURL:        globalURL,
+		userConfig:       userConfig,
+		unmarshaler:      newGlobalUnmarshaler(flags),
+		dispatch:         globalDispatch,
+		embeddedData:     embeddedconfig.Global,
+		embeddedRequired: true,
 		sleep: func() time.Duration {
 			mx.RLock()
 			defer mx.RUnlock()


### PR DESCRIPTION
This avoids sending logs to sentry when we're not actually expecting embedded data.