### PR TITLE
Use new bypass path inside the API

### DIFF
--- a/bypass/bypass.go
+++ b/bypass/bypass.go
@@ -15,13 +15,13 @@ import (
 
 	mrand "math/rand"
 
-	"github.com/getlantern/lantern-cloud/cmd/api/apipb"
 	"github.com/getlantern/flashlight/balancer"
 	"github.com/getlantern/flashlight/chained"
 	"github.com/getlantern/flashlight/common"
 	"github.com/getlantern/flashlight/config"
 	"github.com/getlantern/flashlight/proxied"
 	"github.com/getlantern/golog"
+	"github.com/getlantern/lantern-cloud/cmd/api/apipb"
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 )
@@ -29,8 +29,8 @@ import (
 var log = golog.LoggerFor("bypass")
 
 // The way lantern-cloud is configured, we need separate URLs for domain fronted vs proxied traffic.
-const dfEndpoint = "https://iantem.io/bypass/v1/proxy"
-const proxyEndpoint = "https://bypass.iantem.io/v1/proxy"
+const dfEndpoint = "https://iantem.io/api/v1/bypass"
+const proxyEndpoint = "https://api.iantem.io/v1/bypass"
 
 type bypass struct {
 	infos     map[string]*apipb.ProxyConfig

--- a/bypass/bypass_test.go
+++ b/bypass/bypass_test.go
@@ -3,8 +3,8 @@ package bypass
 import (
 	"testing"
 
-	"github.com/getlantern/lantern-cloud/cmd/api/apipb"
 	"github.com/getlantern/flashlight/common"
+	"github.com/getlantern/lantern-cloud/cmd/api/apipb"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,9 +17,9 @@ func TestHTTPRequest(t *testing.T) {
 	}
 	uc := &common.NullUserConfig{}
 
-	r, err := p.newRequest(uc, "https://bypass.iantem.io/v1/")
+	r, err := p.newRequest(uc, "https://iantem.io/v1/bypass")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "https://bypass.iantem.io/v1/", r.URL.String())
+	assert.Equal(t, "https://iantem.io/v1/bypass", r.URL.String())
 
 }


### PR DESCRIPTION
After discussion with @oxtoacart and @lincolnmantracer, we decided it would be better for bypass to live within the API itself.