### PR TITLE
Temporarily disable shortcut and detour globally and enable Honeycomb

### DIFF
--- a/config/features_test.go
+++ b/config/features_test.go
@@ -138,7 +138,7 @@ func TestDetour(t *testing.T) {
 	gl := globalFromTemplate(t)
 	for _, country := range []string{"cn"} {
 		for _, os := range []string{"android", "windows", "darwin", "linux"} {
-			assert.True(t, gl.FeatureEnabled(FeatureDetour, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("detour is enabled for %s in %s", os, country))
+			assert.False(t, gl.FeatureEnabled(FeatureDetour, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("detour is disabled for %s in %s", os, country))
 		}
 	}
 }
@@ -148,7 +148,7 @@ func TestShortcut(t *testing.T) {
 	for _, country := range []string{"cn", "ir"} {
 		for _, os := range []string{"android", "windows", "darwin", "linux"} {
 			if country != "ir" || os != "android" {
-				assert.True(t, gl.FeatureEnabled(FeatureShortcut, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("shortcut is enabled for %s in %s", os, country))
+				assert.False(t, gl.FeatureEnabled(FeatureShortcut, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("shortcut is disabled for %s in %s", os, country))
 			}
 		}
 	}
@@ -222,8 +222,8 @@ func TestReplicaEnabled(t *testing.T) {
 
 func TestOtelEnabled(t *testing.T) {
 	gl := globalFromTemplate(t)
-	assert.False(t, gl.FeatureEnabled(FeatureOtel, "android", common.DefaultAppName, "7.0.0", 1, false, "ae"), "Otel is disabled for low user")
-	assert.False(t, gl.FeatureEnabled(FeatureOtel, "android", common.DefaultAppName, "7.0.0", 500, false, "ae"), "Otel is disabled for high user")
+	assert.True(t, gl.FeatureEnabled(FeatureOtel, "android", common.DefaultAppName, "7.0.0", 1, false, "ae"), "Otel is enabled for low user in UAE")
+	assert.False(t, gl.FeatureEnabled(FeatureOtel, "android", common.DefaultAppName, "7.0.0", 500, false, "ae"), "Otel is disabled for high user in UAE")
 }
 
 func getReplicaOptionsRoot(t *testing.T) (fos ReplicaOptionsRoot) {

--- a/config_v5/features_test.go
+++ b/config_v5/features_test.go
@@ -138,7 +138,7 @@ func TestDetour(t *testing.T) {
 	gl := globalFromTemplate(t)
 	for _, country := range []string{"cn"} {
 		for _, os := range []string{"android", "windows", "darwin", "linux"} {
-			assert.True(t, gl.FeatureEnabled(FeatureDetour, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("detour is enabled for %s in %s", os, country))
+			assert.False(t, gl.FeatureEnabled(FeatureDetour, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("detour is disabled for %s in %s", os, country))
 		}
 	}
 }
@@ -148,7 +148,7 @@ func TestShortcut(t *testing.T) {
 	for _, country := range []string{"cn", "ir"} {
 		for _, os := range []string{"android", "windows", "darwin", "linux"} {
 			if country != "ir" || os != "android" {
-				assert.True(t, gl.FeatureEnabled(FeatureShortcut, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("shortcut is enabled for %s in %s", os, country))
+				assert.False(t, gl.FeatureEnabled(FeatureShortcut, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("shortcut is disabled for %s in %s", os, country))
 			}
 		}
 	}

--- a/config_v6/features_test.go
+++ b/config_v6/features_test.go
@@ -138,7 +138,7 @@ func TestDetour(t *testing.T) {
 	gl := globalFromTemplate(t)
 	for _, country := range []string{"cn"} {
 		for _, os := range []string{"android", "windows", "darwin", "linux"} {
-			assert.True(t, gl.FeatureEnabled(FeatureDetour, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("detour is enabled for %s in %s", os, country))
+			assert.False(t, gl.FeatureEnabled(FeatureDetour, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("detour is disabled for %s in %s", os, country))
 		}
 	}
 }
@@ -148,7 +148,7 @@ func TestShortcut(t *testing.T) {
 	for _, country := range []string{"cn", "ir"} {
 		for _, os := range []string{"android", "windows", "darwin", "linux"} {
 			if country != "ir" || os != "android" {
-				assert.True(t, gl.FeatureEnabled(FeatureShortcut, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("shortcut is enabled for %s in %s", os, country))
+				assert.False(t, gl.FeatureEnabled(FeatureShortcut, os, common.DefaultAppName, common.Version, 1, false, country), fmt.Sprintf("shortcut is disabled for %s in %s", os, country))
 			}
 		}
 	}

--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -77,6 +77,10 @@ featuresenabled:
       # XXX 2022-08-08, soltzen: Small testbed for phase 1 of the project: https://docs.google.com/document/d/1JUjZHgpnunmwG3wUwlSmCKFwOGOXkkwyGd7cgrOJzbs/edit#heading=h.lf1udh61ebmc
       userfloor: 0
       userceil: 0.01
+  otel:
+    - label: opentelemetry
+      userfloor: 0
+      userceil: 0.01
   yinbi:
     - label: yinbi
       application: lantern
@@ -119,17 +123,16 @@ featuresenabled:
     - label: chat-android-qa
       platforms: android
       versionconstraints: ">=99.0.0"
-    # For building
   ######## New-Style configuration for detour, shortcut and probeproxies. These are disabled by default and have to be enabled in the config. ########
-  detour:
-    - label: cn-detour
-      geocountries: cn
-  shortcut:
-    - label: cn-shortcut
-      geocountries: cn
-    - lable: ir-desktop-shortcut
-      geocountries: ir
-      platforms: windows,darwin,linux
+  #detour:
+  #  - label: cn-detour
+  #    geocountries: cn
+  #shortcut:
+  #  - label: cn-shortcut
+  #    geocountries: cn
+  #  - label: ir-desktop-shortcut
+  #    geocountries: ir
+  #    platforms: windows,darwin,linux
   # probeproxies is not enabled anywhere
   ######## End of New-Style configuration for detour, shortcut and probeproxies ########
 
@@ -467,7 +470,10 @@ replica:
   replicaserviceendpoint: *GlobalReplicaRust
 
 otel:
-  endpoint: telemetry.iantem.io:443
+  endpoint: api.honeycomb.io:443
+  headers:
+    # Note - this key is only authorized to send events, nothing else
+    x-honeycomb-team: D7LRAYj3uCxrSb7WZjO24C
   samplerate: 1000
   opsamplerates:
     client_started: 1


### PR DESCRIPTION
At a minimum, this eliminates a confounding variable when trying to determine how well service is working, especially in China, and will give us more trace data.