### PR TITLE
Re-enable shortcut in China

### DIFF
--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -125,9 +125,9 @@ featuresenabled:
   #detour:
   #  - label: cn-detour
   #    geocountries: cn
-  #shortcut:
-  #  - label: cn-shortcut
-  #    geocountries: cn
+  shortcut:
+    - label: cn-shortcut
+      geocountries: cn
   #  - label: ir-desktop-shortcut
   #    geocountries: ir
   #    platforms: windows,darwin,linux


### PR DESCRIPTION
This re-enables shortcut in China. We disabled shortcut and detour in China about a week ago, and it resulted in about a 60% jump in bandwidth consumption:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/1143966/190617154-d888253c-47ed-40bf-892c-a03e75d63512.png">
  
Meanwhile, user numbers have drifted downward:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/1143966/190617821-c541ae2e-4683-4c3c-bd94-8c3d9b9c61a9.png">
