### PR TITLE
Skip proxying for ArvanCloud S3 and Iran's replica-rust domain

### DIFF
--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -319,6 +319,7 @@ client:
     ss7hc6jm.io:443: 92.223.103.136:443
     www.ss7hc6jm.io:80: 92.223.103.136:80
     ss7hc6jm.io:80: 92.223.103.136:80
+    # Should there be something here for the Iran Replica infrastructure?
 
 
 nameddomainroutingrules:
@@ -395,6 +396,12 @@ domainroutingrules:
   92.223.103.136: md
   s-dt2.cloud.gcore.lu: md
   retracker.bashtel.ru: md
+
+  # Iran direct
+
+  # Should we be using the IP address directly here?
+  ir.ss7hc6jm.io: md
+  s3.ir-thr-at1.arvanstorage.com: md
 
   # Replica http(s) BitTorrent trackers that run on non-standard ports (80 and 443?) should be listed here.
   tracker.opentrackr.org: p


### PR DESCRIPTION
I'm not super familiar with the proxying requirements here, but I think I have it right. I don't think we need to provide DNS resolution because we don't expect ir.ss7hc6jm.io to fail to resolve. Do I have that right?

This can be merged right away if it's correct. It shouldn't affect any users unless the Iran test PR is also merged, and can sit latent just like corresponding Russia configuration is.