### PR TITLE
Add a build flag to turn on config-server proxying

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -10,6 +10,12 @@ import (
 	mrand "math/rand"
 )
 
+// EnableLanternCloudReferralHeader is a build flag which enables config
+// proxying to the lantern-cloud API. Proxying works by setting a header. When
+// config-server sees the header, it proxies the config request to the
+// lantern-cloud API as a 'referral'.
+var EnableLanternCloudReferralHeader string
+
 const (
 	AppHeader                           = "X-Lantern-App"
 	VersionHeader                       = "X-Lantern-Version"
@@ -33,6 +39,7 @@ const (
 	SleepHeader                         = "X-Lantern-Sleep"
 	XBQHeader                           = "XBQ"
 	XBQHeaderv2                         = "XBQv2"
+	LanternCloudReferralHeader          = "X-Lantern-API-Referral"
 )
 
 var (
@@ -51,6 +58,10 @@ func AddCommonNonUserHeaders(uc UserConfig, req *http.Request) {
 	}
 	if len(uc.GetEnabledExperiments()) > 0 {
 		req.Header.Set("x-lantern-dev-experiments", strings.Join(uc.GetEnabledExperiments(), ","))
+	}
+
+	if EnableLanternCloudReferralHeader == "true" {
+		req.Header.Set(LanternCloudReferralHeader, "true")
 	}
 
 	req.Header.Set(PlatformHeader, Platform)

--- a/common/headers.go
+++ b/common/headers.go
@@ -60,7 +60,8 @@ func AddCommonNonUserHeaders(uc UserConfig, req *http.Request) {
 		req.Header.Set("x-lantern-dev-experiments", strings.Join(uc.GetEnabledExperiments(), ","))
 	}
 
-	if EnableLanternCloudReferralHeader == "true" {
+	if strings.ToLower(EnableLanternCloudReferralHeader) == "true" ||
+		EnableLanternCloudReferralHeader == "1" {
 		req.Header.Set(LanternCloudReferralHeader, "true")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -126,10 +126,10 @@ func init() {
 // config onto a channel for processing by a dispatch function. This will read
 // configs in the following order:
 //
-// 1. Configs saved on disk, if any
-// 2. Configs embedded in the binary according to the specified name, if any.
-// 3. Configs fetched remotely, and those will be piped back over and over
-//   again as the remote configs change (but only if they change).
+//  1. Configs saved on disk, if any
+//  2. Configs embedded in the binary according to the specified name, if any.
+//  3. Configs fetched remotely, and those will be piped back over and over
+//     again as the remote configs change (but only if they change).
 //
 // pipeConfig returns a function that can be used to stop polling
 func pipeConfig(opts *options) (stop func()) {


### PR DESCRIPTION
Config-server has the ability to proxy a config request to lantern-cloud, which is a provisional way to enable lantern-cloud proxies. In order to test this, we need a way for developers to turn on that functionality, and we already use build flags in lantern-desktop for similar purposes.