### PR TITLE
Prepare for migration to R2

### DIFF
--- a/config/features.go
+++ b/config/features.go
@@ -55,11 +55,6 @@ type ReplicaOptionsRoot struct {
 	// Options tailored to country. This could be used to pattern match any arbitrary string really.
 	// mapstructure should ignore the field name.
 	ByCountry map[string]ReplicaOptions `mapstructure:",remain"`
-	// Deprecated. An unmatched country uses the embedded ReplicaOptions.ReplicaRustEndpoint.
-	// Removing this will break unmarshalling config.
-	ReplicaRustDefaultEndpoint string
-	// Deprecated. Use ByCountry.ReplicaRustEndpoint.
-	ReplicaRustEndpoints map[string]string
 }
 
 func (ro *ReplicaOptionsRoot) fromMap(m map[string]interface{}) error {
@@ -327,8 +322,8 @@ func (g ClientGroup) Validate() error {
 	return nil
 }
 
-//Includes checks if the ClientGroup includes the user, device and country
-//combination, assuming the group has been validated.
+// Includes checks if the ClientGroup includes the user, device and country
+// combination, assuming the group has been validated.
 func (g ClientGroup) Includes(platform, appName, version string, userID int64, isPro bool, geoCountry string) bool {
 	if g.UserCeil > 0 {
 		// Unknown user ID doesn't belong to any user range

--- a/config/features_test.go
+++ b/config/features_test.go
@@ -160,17 +160,8 @@ func TestReplicaByCountry(t *testing.T) {
 	assert.NotEmpty(globalTrackers)
 	// Check the countries pull in the trackers using the anchor. Just change this if they stop
 	// using the same trackers. I really don't want this to break out the gate is all.
-	assert.Equal(fos.ByCountry["CN"].Trackers, globalTrackers)
 	assert.NotEmpty(fos.ByCountry["RU"].Trackers)
 	assert.Equal(fos.ByCountry["IR"].Trackers, globalTrackers)
-}
-
-// TestReplicaConfigBackwardsCompatibility checks if the old Replica config format (with "ReplicaRustEndpoints") still work with the new config, which has country-specific configs (using ByCountry["RU"]
-func TestReplicaConfigBackwardsCompatibility(t *testing.T) {
-	assert := assert.New(t)
-	fos := getReplicaOptionsRoot(t)
-	// This checks that the alias propagates to the old config correctly.
-	assert.Equal(fos.ByCountry["CN"].ReplicaRustEndpoint, fos.ReplicaRustEndpoints["CN"])
 }
 
 func TestP2PEnabledAndFeatures(t *testing.T) {

--- a/config_v1/features_test.go
+++ b/config_v1/features_test.go
@@ -1,10 +1,8 @@
 package config
 
 import (
-	"bytes"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/getlantern/yaml"
@@ -12,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getlantern/flashlight/common"
-	"github.com/getlantern/flashlight/embeddedconfig"
 )
 
 func TestValidate(t *testing.T) {
@@ -159,31 +156,4 @@ featureoptions:
 
 	require.Equal(t, 1, mat.Config["idsite"])
 	require.Nil(t, mat.Config["k1"])
-}
-
-func TestReplicaByCountry(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	fos := getReplicaOptionsRoot(require)
-	assert.Contains(fos.ByCountry, "RU")
-	assert.NotContains(fos.ByCountry, "AU")
-	assert.NotEmpty(fos.ByCountry)
-	globalTrackers := fos.Trackers
-	assert.NotEmpty(globalTrackers)
-	// Check the countries pull in the trackers using the anchor. Just change this if they stop
-	// using the same trackers. I really don't want this to break out the gate is all.
-	assert.Equal(fos.ByCountry["CN"].Trackers, globalTrackers)
-	// It's okay for Russia to have different trackers.
-	assert.NotEmpty(fos.ByCountry["RU"].Trackers)
-	assert.Equal(fos.ByCountry["IR"].Trackers, globalTrackers)
-}
-
-func getReplicaOptionsRoot(require *require.Assertions) (fos ReplicaOptionsRoot) {
-	var w bytes.Buffer
-	// We could write into a pipe, but that requires concurrency and we're old-school in tests.
-	require.NoError(template.Must(template.New("").Parse(embeddedconfig.GlobalTemplate)).Execute(&w, nil))
-	var g Global
-	require.NoError(yaml.Unmarshal(w.Bytes(), &g))
-	require.NoError(g.UnmarshalFeatureOptions(FeatureReplica, &fos))
-	return
 }

--- a/config_v3/features_test.go
+++ b/config_v3/features_test.go
@@ -133,28 +133,6 @@ func TestMatomoEnabled(t *testing.T) {
 	assert.True(t, gl.FeatureEnabled(FeatureMatomo, common.Platform, common.DefaultAppName, 500, false, "us"), "Matomo is enabled for a high User ID")
 }
 
-func TestReplicaByCountry(t *testing.T) {
-	assert := assert.New(t)
-	fos := getReplicaOptionsRoot(t)
-	assert.Contains(fos.ByCountry, "RU")
-	assert.NotContains(fos.ByCountry, "AU")
-	assert.NotEmpty(fos.ByCountry)
-	globalTrackers := fos.Trackers
-	assert.NotEmpty(globalTrackers)
-	// Check the countries pull in the trackers using the anchor. Just change this if they stop
-	// using the same trackers. I really don't want this to break out the gate is all.
-	assert.Equal(fos.ByCountry["CN"].Trackers, globalTrackers)
-	// It's okay for Russia to have different trackers.
-	assert.NotEmpty(fos.ByCountry["RU"].Trackers)
-	assert.Equal(fos.ByCountry["IR"].Trackers, globalTrackers)
-}
-
-func getReplicaOptionsRoot(t *testing.T) (fos ReplicaOptionsRoot) {
-	g := globalFromTemplate(t)
-	require.NoError(t, g.UnmarshalFeatureOptions(FeatureReplica, &fos))
-	return
-}
-
 func globalFromTemplate(t *testing.T) *Global {
 	var w bytes.Buffer
 	// We could write into a pipe, but that requires concurrency and we're old-school in tests.

--- a/config_v4/features_test.go
+++ b/config_v4/features_test.go
@@ -154,22 +154,6 @@ func TestNoShortcut(t *testing.T) {
 	}
 }
 
-func TestReplicaByCountry(t *testing.T) {
-	assert := assert.New(t)
-	fos := getReplicaOptionsRoot(t)
-	assert.Contains(fos.ByCountry, "RU")
-	assert.NotContains(fos.ByCountry, "AU")
-	assert.NotEmpty(fos.ByCountry)
-	globalTrackers := fos.Trackers
-	assert.NotEmpty(globalTrackers)
-	// Check the countries pull in the trackers using the anchor. Just change this if they stop
-	// using the same trackers. I really don't want this to break out the gate is all.
-	assert.Equal(fos.ByCountry["CN"].Trackers, globalTrackers)
-	// It's okay for Russia to have different trackers.
-	assert.NotEmpty(fos.ByCountry["RU"].Trackers)
-	assert.Equal(fos.ByCountry["IR"].Trackers, globalTrackers)
-}
-
 func TestChatEnabled(t *testing.T) {
 	gl := globalFromTemplate(t)
 	assert.False(t, gl.FeatureEnabled(FeatureChat, "android", common.DefaultAppName, "7.0.0", 1, false, "ae"), "Chat is disabled in UAE when running 7.0.0")
@@ -185,12 +169,6 @@ func TestReplicaEnabled(t *testing.T) {
 	assert.False(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "7.0.0", 1, false, "us"), "Replica is not enabled in USA when running 7.0.0")
 	assert.False(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "6.9.7", 1, false, "ru"), "Replica is not enabled in Russia when running 6.9.7")
 	assert.True(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "99.0.0", 1, false, "ru"), "Replica is enabled in Russia when running QA version 99.0.0")
-}
-
-func getReplicaOptionsRoot(t *testing.T) (fos ReplicaOptionsRoot) {
-	g := globalFromTemplate(t)
-	require.NoError(t, g.UnmarshalFeatureOptions(FeatureReplica, &fos))
-	return
 }
 
 func globalFromTemplate(t *testing.T) *Global {

--- a/config_v5/features_test.go
+++ b/config_v5/features_test.go
@@ -156,22 +156,6 @@ func TestShortcut(t *testing.T) {
 	}
 }
 
-func TestReplicaByCountry(t *testing.T) {
-	assert := assert.New(t)
-	fos := getReplicaOptionsRoot(t)
-	assert.Contains(fos.ByCountry, "RU")
-	assert.NotContains(fos.ByCountry, "AU")
-	assert.NotEmpty(fos.ByCountry)
-	globalTrackers := fos.Trackers
-	assert.NotEmpty(globalTrackers)
-	// Check the countries pull in the trackers using the anchor. Just change this if they stop
-	// using the same trackers. I really don't want this to break out the gate is all.
-	assert.Equal(fos.ByCountry["CN"].Trackers, globalTrackers)
-	// It's okay for Russia to have different trackers.
-	assert.NotEmpty(fos.ByCountry["RU"].Trackers)
-	assert.Equal(fos.ByCountry["IR"].Trackers, globalTrackers)
-}
-
 func TestChatEnabled(t *testing.T) {
 	gl := globalFromTemplate(t)
 	assert.False(t, gl.FeatureEnabled(FeatureChat, "android", common.DefaultAppName, "7.0.0", 1, false, "ae"), "Chat is disabled in UAE when running 7.0.0")
@@ -187,12 +171,6 @@ func TestReplicaEnabled(t *testing.T) {
 	assert.False(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "7.0.0", 1, false, "us"), "Replica is not enabled in USA when running 7.0.0")
 	assert.False(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "6.9.7", 1, false, "ru"), "Replica is not enabled in Russia when running 6.9.7")
 	assert.True(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "99.0.0", 1, false, "ru"), "Replica is enabled in Russia when running QA version 99.0.0")
-}
-
-func getReplicaOptionsRoot(t *testing.T) (fos ReplicaOptionsRoot) {
-	g := globalFromTemplate(t)
-	require.NoError(t, g.UnmarshalFeatureOptions(FeatureReplica, &fos))
-	return
 }
 
 func globalFromTemplate(t *testing.T) *Global {

--- a/config_v6/features_test.go
+++ b/config_v6/features_test.go
@@ -156,22 +156,6 @@ func TestShortcut(t *testing.T) {
 	}
 }
 
-func TestReplicaByCountry(t *testing.T) {
-	assert := assert.New(t)
-	fos := getReplicaOptionsRoot(t)
-	assert.Contains(fos.ByCountry, "RU")
-	assert.NotContains(fos.ByCountry, "AU")
-	assert.NotEmpty(fos.ByCountry)
-	globalTrackers := fos.Trackers
-	assert.NotEmpty(globalTrackers)
-	// Check the countries pull in the trackers using the anchor. Just change this if they stop
-	// using the same trackers. I really don't want this to break out the gate is all.
-	assert.Equal(fos.ByCountry["CN"].Trackers, globalTrackers)
-	// It's okay for Russia to have different trackers.
-	assert.NotEmpty(fos.ByCountry["RU"].Trackers)
-	assert.Equal(fos.ByCountry["IR"].Trackers, globalTrackers)
-}
-
 func TestChatEnabled(t *testing.T) {
 	gl := globalFromTemplate(t)
 	assert.False(t, gl.FeatureEnabled(FeatureChat, "android", common.DefaultAppName, "7.0.0", 1, false, "ae"), "Chat is disabled in UAE when running 7.0.0")
@@ -187,12 +171,6 @@ func TestReplicaEnabled(t *testing.T) {
 	assert.False(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "7.0.0", 1, false, "us"), "Replica is not enabled in USA when running 7.0.0")
 	assert.False(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "6.9.10", 1, false, "ru"), "Replica is not enabled in Russia when running 6.9.10")
 	assert.True(t, gl.FeatureEnabled(FeatureReplica, "android", common.DefaultAppName, "99.0.0", 1, false, "us"), "Replica is enabled in USA when running QA version 99.0.0")
-}
-
-func getReplicaOptionsRoot(t *testing.T) (fos ReplicaOptionsRoot) {
-	g := globalFromTemplate(t)
-	require.NoError(t, g.UnmarshalFeatureOptions(FeatureReplica, &fos))
-	return
 }
 
 func globalFromTemplate(t *testing.T) *Global {

--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -227,6 +227,8 @@ featureoptions:
     - https://s3.eu-central-1.amazonaws.com/getlantern-replica-frankfurt/
     - https://s3-eu-central-1.amazonaws.com/getlantern-replica-frankfurt/
     - https://d3mm73d1kmj7zd.cloudfront.net/
+    # This is a domain access endpoint for the Replica Cloudflare R2 bucket. See https://dash.cloudflare.com/1c693b3f1031ed33f68653b1e67dfbef/r2/overview/buckets/replica/settings and the domain's DNS configuration.
+    - https://replica-r2.lantern.io/
     replicarustendpoint: &FrankfurtReplicaRust http://replica-search-aws.lantern.io/
     staticpeeraddrs: []
     # This list is from https://github.com/getlantern/dhtup/blob/c8fde3e1a38abcb9709df07194ea2de3ae33bdbe/trackers.go#L14
@@ -239,11 +241,6 @@ featureoptions:
     - https://tracker.nanoha.org:443/announce
     - http://t.nyaatracker.com:80/announce
     webseedbaseurls: *AllReplicaBaseUrls
-
-    # These are for compatibility with clients that don't load all options per-country.
-    replicarustdefaultendpoint: *FrankfurtReplicaRust
-    replicarustendpoints:
-      "CN": &GlobalReplicaRust http://replica-search.lantern.io/
 
     # Here follows options per-country
 
@@ -259,16 +256,6 @@ featureoptions:
       trackers: *GlobalTrackers
       webseedbaseurls: *AllReplicaBaseUrls
       staticpeeraddrs: [&RussiaReplicaPeers "94.242.59.118:42069"]
-    "CN":
-      metadatabaseurls:
-      - https://s3.ap-southeast-1.amazonaws.com/getlantern-replica/
-      - https://s3-ap-southeast-1.amazonaws.com/getlantern-replica/
-      replicarustendpoint: *GlobalReplicaRust
-      staticpeeraddrs: []
-      trackers: *GlobalTrackers
-      webseedbaseurls:
-      - https://s3.ap-southeast-1.amazonaws.com/getlantern-replica/
-      - https://s3-ap-southeast-1.amazonaws.com/getlantern-replica/
 
 adsettings:
   nativebannerzoneid: 5d3787399a1a710001b1ba32
@@ -429,14 +416,6 @@ proxiedsites:
 trustedcas: {{range .cas}}
 - commonname: "{{.CommonName}}"
   cert: "{{.Cert}}"{{end}}
-
-# This is the original global config, still here for compatibility with very old clients.
-replica:
-  webseedbaseurls: *AllReplicaBaseUrls
-  trackers: *GlobalTrackers
-  staticpeeraddrs: []
-  metadatabaseurls: *AllReplicaBaseUrls
-  replicaserviceendpoint: *FrankfurtReplicaRust
 
 otel:
   endpoint: api.honeycomb.io:443


### PR DESCRIPTION
- Add R2 endpoint to S3
- Switch China to use Frankfurt index (includes their own too)
- Remove old Replica config (Fixes https://github.com/getlantern/lantern-internal/issues/5815)

See https://docs.google.com/document/d/1HjEvkEMaFOPhli7xjOU_-8ieLlJuWAYUum4YgEv7-Tk/edit for context.