### PR TITLE
Improve certificate pinning

### DIFF
--- a/.github/workflows/compile_genconfig.yml
+++ b/.github/workflows/compile_genconfig.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.18
     - name: Granting private modules access
       run: |
         git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/globalconfig.yml
+++ b/.github/workflows/globalconfig.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.18
     - name: Granting private modules access
       run: |
           git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.18
     - name: Set up gotestfmt
       uses: gotesttools/gotestfmt-action@v2
       with:

--- a/chained/tlsmasq_impl.go
+++ b/chained/tlsmasq_impl.go
@@ -113,7 +113,7 @@ func newTLSMasqImpl(configDir, name, addr string, pc *config.ProxyConfig, uc com
 			ServerName:            host,
 			InsecureSkipVerify:    proxyTLS.InsecureSkipVerify,
 			VerifyPeerCertificate: proxyTLS.VerifyPeerCertificate,
-			RootCAs:               proxyTLS.RootCAs.Clone(),
+			RootCAs:               proxyTLS.RootCAs,
 			KeyLogWriter:          proxyTLS.KeyLogWriter,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getlantern/flashlight
 
-go 1.19
+go 1.18
 
 replace github.com/elazarl/goproxy => github.com/getlantern/goproxy v0.0.0-20220805074304-4a43a9ed4ec6
 


### PR DESCRIPTION
We pin TLS certificates when connecting to HTTPS proxies. This is because our proxies use self-signed certificates, communicated out-of-band to clients via the proxy config. We currently do this manually, through a byte-wise comparison of the configured certificate and the certificate the server provides.

One issue with this is that it defeats our "hello rolling" logic, which aims to rotate to a new TLS ClientHello if anything goes wrong in the TLS handshake with the proxy. If certificate verification happens outside of the handshake, the hello-rolling logic will not trigger.

This causes a bug when clients try to connect to a session resumption proxy. We use a ClientHello modeled after the user's default web browser. If the user's browser does not support session tickets, the client's request will be "reflected" to the proxy's masquerade origin. The client will realize something is amiss when it checks the certificate, but because the check occurs outside of the handshake, the client will not fallback to other (more reliable) ClientHellos. Instead, the client will continue to use the bad ClientHello and forever fail to establish a connection to the proxy.

The solution is to move to a more standard method of certificate verification. We configure the proxy certificate as the root CA and let crypto/tls handle verification as part of the handshake.