### PR TITLE
add ChatGPT to proxied sites list

### DIFF
--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -428,6 +428,9 @@ domainroutingrules:
   yinshix.com: p
   yinshi.iantem.io: p
 
+  # ChatGPT
+  chat.openai.com: p
+
 proxiedsites:
   delta:
     additions: []


### PR DESCRIPTION
by user request - blocked for them in China