### PR TITLE
add platform version header

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -31,6 +31,7 @@ const (
 	IfNoneMatchHeader                   = "X-Lantern-If-None-Match"
 	PingHeader                          = "X-Lantern-Ping"
 	PlatformHeader                      = "X-Lantern-Platform"
+	PlatformVersionHeader               = "X-Lantern-PlatVer"
 	ProxyDialTimeoutHeader              = "X-Lantern-Dial-Timeout"
 	ClientCountryHeader                 = "X-Lantern-Client-Country"
 	RandomNoiseHeader                   = "X-Lantern-Rand"
@@ -60,6 +61,7 @@ func AddCommonNonUserHeaders(uc UserConfig, req *http.Request) {
 	}
 
 	req.Header.Set(PlatformHeader, Platform)
+	req.Header.Set(PlatformVersionHeader, platformVersion())
 	req.Header.Set(AppHeader, uc.GetAppName())
 	req.Header.Set(KernelArchHeader, kernelArch())
 	req.Header.Add(SupportedDataCapsHeader, "monthly")
@@ -74,6 +76,19 @@ func AddCommonNonUserHeaders(uc UserConfig, req *http.Request) {
 	// We include a random length string here to make it harder for censors to identify lantern
 	// based on consistent packet lengths.
 	req.Header.Add(RandomNoiseHeader, randomizedString())
+}
+
+func platformVersion() string {
+	_, _, pver, err := host.PlatformInformation()
+	if err != nil {
+		log.Debugf("omitting os version header because: %v", err)
+		return "noosversion-" + Platform + "-" + err.Error()
+	}
+	if pver == "" {
+		log.Debugf("omitting os version header because it is empty")
+		return "emptyosversion-" + Platform
+	}
+	return pver
 }
 
 // kernelArch returns the kernel architecture, or "noarch-" and platform if it can't be determined.

--- a/common/headers_test.go
+++ b/common/headers_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/shirou/gopsutil/v3/host"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,6 +48,11 @@ func assertHeaders(t *testing.T, resHeaders http.Header, expHeaders map[string]s
 func TestArch(t *testing.T) {
 	arch := kernelArch()
 	assert.NotEmpty(t, arch)
+
+	_, plat, pver, err := host.PlatformInformation()
+	fmt.Printf("PlatformInformation: %s %s %s %v\n", plat, pver, arch, err)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, pver)
 }
 
 func TestCORSMiddleware(t *testing.T) {

--- a/common/headers_test.go
+++ b/common/headers_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shirou/gopsutil/v3/host"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,9 +48,7 @@ func TestArch(t *testing.T) {
 	arch := kernelArch()
 	assert.NotEmpty(t, arch)
 
-	_, plat, pver, err := host.PlatformInformation()
-	fmt.Printf("PlatformInformation: %s %s %s %v\n", plat, pver, arch, err)
-	assert.NoError(t, err)
+	pver := platformVersion()
 	assert.NotEmpty(t, pver)
 }
 


### PR DESCRIPTION
This is relevant because, for example, Go 1.21 stopped supporting windows 7.