### PR TITLE
Create dialers in parallel to avoid them blocking first connect

### DIFF
--- a/chained/proxy.go
+++ b/chained/proxy.go
@@ -80,29 +80,43 @@ func CreateDialers(configDir string, proxies map[string]*config.ProxyConfig, uc 
 func CreateDialersMap(configDir string, proxies map[string]*config.ProxyConfig, uc common.UserConfig) map[string]bandit.Dialer {
 	mappedDialers := make(map[string]bandit.Dialer)
 	groups := groupByMultipathEndpoint(proxies)
+
+	// We parallelize the creation of the dialers because some of them may take
+	// a long time to initialize (e.g. tls-based proxies that try to read
+	// browser hellos on creation time).
+	wg := &sync.WaitGroup{}
 	for endpoint, group := range groups {
 		if endpoint == "" {
 			// Also print the stack trace to help us debug
 			log.Debugf("Creating map for %d individual chained servers", len(group))
 			for name, s := range group {
-				dialer, err := CreateDialer(configDir, name, s, uc)
-				if err != nil {
-					log.Errorf("Unable to configure chained server %v. Received error: %v", name, err)
-					continue
-				}
-				log.Debugf("Adding chained server: %v", dialer.JustifiedLabel())
-				mappedDialers[name] = dialer
+				wg.Add(1)
+				go func(name string, s *config.ProxyConfig) {
+					dialer, err := CreateDialer(configDir, name, s, uc)
+					if err != nil {
+						log.Errorf("Unable to configure chained server %v. Received error: %v", name, err)
+						return
+					}
+					log.Debugf("Adding chained server: %v", dialer.JustifiedLabel())
+					mappedDialers[name] = dialer
+					wg.Done()
+				}(name, s)
 			}
 		} else {
 			log.Debugf("Creating map for %d chained servers for multipath endpoint %s", len(group), endpoint)
-			dialer, err := CreateMPDialer(configDir, endpoint, group, uc)
-			if err != nil {
-				log.Errorf("Unable to configure multipath server to %v. Received error: %v", endpoint, err)
-				continue
-			}
-			mappedDialers[endpoint] = dialer
+			wg.Add(1)
+			go func(endpoint string, group map[string]*config.ProxyConfig) {
+				dialer, err := CreateMPDialer(configDir, endpoint, group, uc)
+				if err != nil {
+					log.Errorf("Unable to configure multipath server to %v. Received error: %v", endpoint, err)
+					return
+				}
+				mappedDialers[endpoint] = dialer
+				wg.Done()
+			}(endpoint, group)
 		}
 	}
+	wg.Wait()
 	return mappedDialers
 }
 

--- a/chained/proxy.go
+++ b/chained/proxy.go
@@ -85,8 +85,9 @@ func CreateDialersMap(configDir string, proxies map[string]*config.ProxyConfig, 
 	// browser hellos on creation time).
 	wg := &sync.WaitGroup{}
 
-	// Create a channel for results of the dialers
-	results := make(chan bandit.Dialer, 30)
+	// Create a channel for results of the dialers. Make sure it's plenty big
+	// to avoid blocking.
+	results := make(chan bandit.Dialer, len(proxies)*2)
 	for endpoint, group := range groups {
 		if endpoint == "" {
 			// Also print the stack trace to help us debug


### PR DESCRIPTION
Currently each dialer, particularly hello-browser-based dialers, can take a long time to connect (5 seconds). We create them serially, so 7 dialers means a 35 second delay on startup. This parallelizes that.