### PR TITLE
Add cachedHello to iOS TLS configuration

### DIFF
--- a/chained/tls_config_ios.go
+++ b/chained/tls_config_ios.go
@@ -7,6 +7,10 @@ import (
 	"fmt"
 )
 
+func cachedHello(configDir string) (*helloSpec, error) {
+	return nil, fmt.Errorf("cachedHello not supported on iOS")
+}
+
 func ActivelyObtainBrowserHello(ctx context.Context, configDir string) (*helloSpec, error) {
 	return nil, fmt.Errorf("activelyObtainBrowserHello not supported on iOS")
 }


### PR DESCRIPTION
Resolves "undefined: cachedHello" issue compiling the Go backend code for iOS:

```
	gomobile bind -target=ios,iossimulator \
	-tags='headless lantern ios netgo' \
	-ldflags="-X github.com/getlantern/android-lantern/internalsdk.RevisionDate=20240206.142333 -X github.com/getlantern/android-lantern/internalsdk.ApplicationVersion=9999.99.99 -X github.com/getlantern/flashlight/v7/common.StagingMode=false"  \
    		 \
    		github.com/getlantern/android-lantern/internalsdk github.com/getlantern/pathdb/testsupport github.com/getlantern/pathdb/minisql github.com/getlantern/flashlight/v7/ios
gomobile: iossimulator/arm64: go build -tags headless,lantern,ios,netgo -ldflags -X github.com/getlantern/android-lantern/internalsdk.RevisionDate=20240206.142333 -X github.com/getlantern/android-lantern/internalsdk.ApplicationVersion=9999.99.99 -X github.com/getlantern/flashlight/v7/common.StagingMode=false -buildmode=c-archive -o /var/folders/j5/yrnkkcxx6wlcr7h2f574qfjc0000gn/T/gomobile-work-3818622677/internalsdk-iossimulator-arm64.a ./gobind failed: exit status 1
# crawshaw.io/sqlite
In file included from /Users/todd/go/pkg/mod/crawshaw.io/sqlite@v0.3.3-0.20220618202545-d1964889ea3c/static.go:20:
/Users/todd/go/pkg/mod/crawshaw.io/sqlite@v0.3.3-0.20220618202545-d1964889ea3c/./c/sqlite3.c:34913:8: warning: "gethostuuid() is disabled." [-W#warnings]
# github.com/eycorsican/go-tun2socks/core
In file included from /Users/todd/go/pkg/mod/github.com/getlantern/go-tun2socks@v1.16.12-0.20201218023150-b68f09e5ae93/core/c_core.go:9:
/Users/todd/go/pkg/mod/github.com/getlantern/go-tun2socks@v1.16.12-0.20201218023150-b68f09e5ae93/core/c/core/mem.c:1005:105: warning: format specifies type 'unsigned int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
/Users/todd/go/pkg/mod/github.com/getlantern/go-tun2socks@v1.16.12-0.20201218023150-b68f09e5ae93/core/c/include/lwip/debug.h:150:53: note: expanded from macro 'LWIP_DEBUGF'
/Users/todd/go/pkg/mod/github.com/getlantern/go-tun2socks@v1.16.12-0.20201218023150-b68f09e5ae93/core/c/custom/arch/cc_others.h:83:42: note: expanded from macro 'LWIP_PLATFORM_DIAG'
# github.com/getlantern/flashlight/v7/chained
/Users/todd/go/pkg/mod/github.com/getlantern/flashlight/v7@v7.6.47/chained/tls_config.go:136:16: undefined: cachedHello
```