### PR TITLE
Check for nil response when logging chained request failed

### DIFF
--- a/proxied/proxied.go
+++ b/proxied/proxied.go
@@ -351,7 +351,11 @@ func (df *dualFetcher) do(req *http.Request, chainedRT http.RoundTripper, ddfRT 
 			atomic.StoreInt64(&chainedRTT, int64(elapsed))
 			switchToChainedIfRequired()
 		} else {
-			log.Debugf("Chained request to %v failed with a %v status code", req.URL.String(), res.StatusCode)
+			if res != nil {
+				log.Debugf("Chained request to %v failed with a %v status code", req.URL.String(), res.StatusCode)
+			} else {
+				log.Debugf("Chained request to %v failed", req.URL.String())
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue starting flashlight on iOS:

```
DEBUG flashlight.geolookup: geolookup.go:134 Requested refresh
DEBUG fronted: direct.go:114 Vetting 10 initial candidates in series
DEBUG ios: config.go:132 Updating global config
DEBUG geolookup: geolookup.go:119 Fetching ip... [op=geolookup root_op=geolookup]
DEBUG flashlight.proxied: ops.go:55 Using dual fronter for request to: "geo.getiantem.org" [http_method=GET http_proto=HTTP/1.1 op=dual_fetcher_round_trip origin_port=80 parallel=true root_op=geolookup]
DEBUG flashlight.proxied: proxied.go:330 Sending DDF request. With body? false [http_method=GET http_proto=HTTP/1.1 op=dualfetcher origin_port=80 parallel=true proxy_type=fronted root_op=geolookup]
DEBUG flashlight.proxied: proxied.go:346 Sending chained request. With body? false [http_method=GET http_proto=HTTP/1.1 op=dualfetcher origin_port=80 parallel=true proxy_type=chained root_op=geolookup]
DEBUG flashlight.proxied: proxied.go:481 Got an error in first response: chained proxy unavailable [http_method=GET http_proto=HTTP/1.1 op=dualfetcher origin_port=80 parallel=true proxy_type=chained root_op=geolookup]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x104684e94]

goroutine 67 [running]:
github.com/getlantern/flashlight/v7/proxied.(*dualFetcher).do.func4()
	/Users/todd/go/src/github.com/getlantern/flashlight/proxied/proxied.go:354 +0x1b4
github.com/getlantern/context.(*context).Go.func1()
	/Users/todd/go/pkg/mod/github.com/getlantern/context@v0.0.0-20220418194847-3d5e7a086201/context.go:168 +0x54
created by github.com/getlantern/context.(*context).Go in goroutine 43
	/Users/todd/go/pkg/mod/github.com/getlantern/context@v0.0.0-20220418194847-3d5e7a086201/context.go:165 +0x70
FAIL	github.com/getlantern/flashlight/v7/ios	0.492s

```