### PR TITLE
Improve multi-armed bandit dial timeout handling

### DIFF
--- a/bandit/bandit.go
+++ b/bandit/bandit.go
@@ -101,7 +101,8 @@ func (o *BanditDialer) DialContext(ctx context.Context, network, addr string) (n
 			if err != nil {
 				// There is no more time left in the overall dial timeout, so we
 				// should stop trying to dial.
-				break
+				log.Debug("Could not allocate partial deadline, stopping dialing.")
+				return nil, err
 			}
 			if partialDeadline.Before(deadline) {
 				var cancel context.CancelFunc

--- a/bandit/bandit.go
+++ b/bandit/bandit.go
@@ -150,8 +150,10 @@ func (o *BanditDialer) DialContext(ctx context.Context, network, addr string) (n
 	}
 }
 
-// partialDeadline returns the deadline to use for a single address,
-// when multiple addresses are pending.
+// partialDeadline returns the deadline to use for a single proxy dialer depending
+// on the number of proxies remaining. This is to ensure that we don't spend too
+// much time on any one proxy, or too little time.
+//
 // This is adapated from dial.go in the standard library:
 // https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/net/dial.go;l=197
 func partialDeadline(deadline time.Time, addrsRemaining int) (time.Time, error) {

--- a/chained/chained_test.go
+++ b/chained/chained_test.go
@@ -164,11 +164,10 @@ func TestBadAddressToServer(t *testing.T) {
 		return nil, fmt.Errorf("fail intentionally")
 	}}
 	l := startServer(t)
-	req, err := p.buildCONNECTRequest("somebadaddressasdfdasfds.asdfasdf.dfads:532400", 5*time.Second+2*time.Millisecond+1*time.Nanosecond)
+	req, err := p.buildCONNECTRequest("somebadaddressasdfdasfds.asdfasdf.dfads:532400")
 	if err != nil {
 		t.Fatalf("Unable to build request: %s", err)
 	}
-	assert.Equal(t, "5003", req.Header.Get(common.ProxyDialTimeoutHeader))
 	conn, err := net.DialTimeout("tcp", l.Addr().String(), 10*time.Second)
 	if err != nil {
 		t.Fatalf("Unable to dial server: %s", err)

--- a/common/headers.go
+++ b/common/headers.go
@@ -30,7 +30,6 @@ const (
 	PingHeader                          = "X-Lantern-Ping"
 	PlatformHeader                      = "X-Lantern-Platform"
 	PlatformVersionHeader               = "X-Lantern-PlatVer"
-	ProxyDialTimeoutHeader              = "X-Lantern-Dial-Timeout"
 	ClientCountryHeader                 = "X-Lantern-Client-Country"
 	RandomNoiseHeader                   = "X-Lantern-Rand"
 	SleepHeader                         = "X-Lantern-Sleep"


### PR DESCRIPTION
This improves our handling of dial timeouts with multiple dialers for multi-armed bandit to avoid situations where a single timing out dialer wreaks havoc with all dialers.