### PR TITLE
Sample replica_metrics traces at a rate of 1 in 10,000

### DIFF
--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -415,4 +415,4 @@ otel:
     proxy_rank: 24000
     # Once per MB?
     replica_torrent_peer_sent_data: 16
-    replica_metrics: 1
+    replica_metrics: 10000


### PR DESCRIPTION
This will drastically reduce the number of events we are sending to Honeycomb, allowing us to stay under the quota for our current plan and even to move down to a lower payment tier.

This decision was discussed with and approved by anacrolix@getlantern.org