### PR TITLE
Removing sampling from autoupdate spans

### DIFF
--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -418,3 +418,4 @@ otel:
     replica_torrent_peer_sent_data: 16
     replica_metrics: 10000
     autoupdate_download: 1
+    autoupdate_install: 1

--- a/embeddedconfig/global.yaml.tmpl
+++ b/embeddedconfig/global.yaml.tmpl
@@ -417,3 +417,4 @@ otel:
     # Once per MB?
     replica_torrent_peer_sent_data: 16
     replica_metrics: 10000
+    autoupdate_download: 1


### PR DESCRIPTION
This PR removes span sampling from autoupdate install and download operations. I'm doing this with the hope to get more information about autoupdate issues that are not happening as expected.