### PR TITLE
Skip failing dialers if we have succeeding ones

### DIFF
--- a/bandit/bandit.go
+++ b/bandit/bandit.go
@@ -199,9 +199,10 @@ func (o *BanditDialer) chooseDialerForDomain(network, addr string) (Dialer, int)
 	// Loop through the number of dialers we have and select the one that is best
 	// for the given domain.
 	chosenArm := o.bandit.SelectArm(rand.Float64())
+	var dialer Dialer
 	notAllFailing := hasNotFailing(o.dialers)
 	for i := 0; i < (len(o.dialers) * 2); i++ {
-		dialer := o.dialers[chosenArm]
+		dialer = o.dialers[chosenArm]
 		if (dialer.ConsecFailures() > 0 && notAllFailing) || !dialer.SupportsAddr(network, addr) {
 			// If the chosen dialer has consecutive failures and there are other
 			// dialers that are succeeding, we should choose a different dialer.
@@ -209,11 +210,11 @@ func (o *BanditDialer) chooseDialerForDomain(network, addr string) (Dialer, int)
 			// If the chosen dialer does not support the address, we should also
 			// choose a different dialer.
 			chosenArm = differentArm(chosenArm, len(o.dialers))
-		} else {
-			break
+			continue
 		}
+		break
 	}
-	return o.dialers[chosenArm], chosenArm
+	return dialer, chosenArm
 }
 
 // Choose a different arm than the one we already have, if possible.

--- a/bandit/bandit.go
+++ b/bandit/bandit.go
@@ -189,9 +189,10 @@ func (o *BanditDialer) chooseDialerForDomain(network, addr string) (Dialer, int)
 	// Loop through the number of dialers we have and select the one that is best
 	// for the given domain.
 	chosenArm := o.bandit.SelectArm(rand.Float64())
-	for i := 0; i < len(o.dialers); i++ {
+	succeeding := hasSucceedingDialer(o.dialers)
+	for i := 0; i < (len(o.dialers) * 2); i++ {
 		dialer := o.dialers[chosenArm]
-		if (dialer.ConsecFailures() > 0 && hasSucceedingDialer(o.dialers)) || !dialer.SupportsAddr(network, addr) {
+		if (dialer.ConsecFailures() > 0 && succeeding) || !dialer.SupportsAddr(network, addr) {
 			// If the chosen dialer has consecutive failures and there are other
 			// dialers that are succeeding, we should choose a different dialer.
 			//

--- a/bandit/bandit_test.go
+++ b/bandit/bandit_test.go
@@ -11,6 +11,7 @@ import (
 
 	bandit "github.com/alextanhongpin/go-bandit"
 	"github.com/getlantern/flashlight/v7/stats"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,16 +70,12 @@ func TestBanditDialer_chooseDialerForDomain(t *testing.T) {
 				Dialers: tt.fields.dialers,
 			}
 			o, err := New(opts)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			got, got1 := o.chooseDialerForDomain(tt.args.network, tt.args.addr)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BanditDialer.chooseDialerForDomain() got = %v, want %v", got, tt.want)
 			}
-			if got1 != tt.want1 {
-				t.Errorf("BanditDialer.chooseDialerForDomain() got1 = %v, want %v", got1, tt.want1)
-			}
+			assert.Equal(t, tt.want1, got1, "BanditDialer.chooseDialerForDomain() got1 = %v, want %v", got1, tt.want1)
 		})
 	}
 }

--- a/bandit/bandit_test.go
+++ b/bandit/bandit_test.go
@@ -14,11 +14,80 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBanditDialer_chooseDialerForDomain(t *testing.T) {
+	baseDialer := newTcpConnDialer()
+	type fields struct {
+		dialers []Dialer
+	}
+	type args struct {
+		network string
+		addr    string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   Dialer
+		want1  int
+	}{
+		{
+			name: "should return the first dialer if there's only one dialer",
+			fields: fields{
+				dialers: []Dialer{baseDialer},
+			},
+			args: args{
+				network: "tcp",
+				addr:    "localhost:8080",
+			},
+			want:  baseDialer,
+			want1: 0,
+		},
+		{
+			name: "choose the non-failing dialer if there are multiple dialers",
+			fields: fields{
+				dialers: []Dialer{
+					newFailingTcpConnDialer(),
+					newFailingTcpConnDialer(),
+					newFailingTcpConnDialer(),
+					newFailingTcpConnDialer(),
+					baseDialer,
+					newFailingTcpConnDialer(),
+					newFailingTcpConnDialer(),
+				},
+			},
+			args: args{
+				network: "tcp",
+				addr:    "localhost:8080",
+			},
+			want:  baseDialer,
+			want1: 4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := Options{
+				Dialers: tt.fields.dialers,
+			}
+			o, err := New(opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, got1 := o.chooseDialerForDomain(tt.args.network, tt.args.addr)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BanditDialer.chooseDialerForDomain() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("BanditDialer.chooseDialerForDomain() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
 func TestParallelDial(t *testing.T) {
 	dialers := []Dialer{
-		&tcpConnDialer{shouldFail: true},
-		&tcpConnDialer{shouldFail: true},
-		&tcpConnDialer{shouldFail: true},
+		newFailingTcpConnDialer(),
+		newFailingTcpConnDialer(),
+		newFailingTcpConnDialer(),
 		newTcpConnDialer(),
 	}
 
@@ -255,6 +324,12 @@ func newTcpConnDialer() Dialer {
 	}
 }
 
+func newFailingTcpConnDialer() Dialer {
+	return &tcpConnDialer{
+		shouldFail: true,
+	}
+}
+
 type tcpConnDialer struct {
 	shouldFail bool
 	client     net.Conn
@@ -280,12 +355,18 @@ func (*tcpConnDialer) Attempts() int64 {
 }
 
 // ConsecFailures implements Dialer.
-func (*tcpConnDialer) ConsecFailures() int64 {
+func (t *tcpConnDialer) ConsecFailures() int64 {
+	if t.shouldFail {
+		return 1
+	}
 	return 0
 }
 
 // ConsecSuccesses implements Dialer.
-func (*tcpConnDialer) ConsecSuccesses() int64 {
+func (t *tcpConnDialer) ConsecSuccesses() int64 {
+	if !t.shouldFail {
+		return 1
+	}
 	return 0
 }
 
@@ -376,7 +457,10 @@ func (*tcpConnDialer) Succeeding() bool {
 }
 
 // Successes implements Dialer.
-func (*tcpConnDialer) Successes() int64 {
+func (t *tcpConnDialer) Successes() int64 {
+	if !t.shouldFail {
+		return 1
+	}
 	return 0
 }
 


### PR DESCRIPTION
@hwh33 and I observed in user logs how the bandit dialer will continue to retry/explore dialers that are failing to connect at all. 10% of the time, it will attempt dialers that are not the best dialer. Some percentage of those dialers could be not connecting at all. This change ignores those dialers if we have others that are succeeding.