### PR TITLE
Reverting go version due to 1.23 causing test failures on desktop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/getlantern/flashlight/v7
 
-go 1.23
+go 1.22.3
 
-toolchain go1.23.2
+toolchain go1.22.8
 
 replace github.com/elazarl/goproxy => github.com/getlantern/goproxy v0.0.0-20220805074304-4a43a9ed4ec6
 


### PR DESCRIPTION
Go 1.23 is causing test failures on desktop, presumably as a result of changes to the http package. Reverting for now.

https://github.com/getlantern/lantern-desktop/actions/runs/11613700386