### PR TITLE
allow blocking otel-reconfiguration

### DIFF
--- a/otel/otel.go
+++ b/otel/otel.go
@@ -25,6 +25,8 @@ var (
 
 	stopper   func()
 	stopperMx sync.Mutex
+
+	stopReconfiguration bool
 )
 
 type Config struct {
@@ -34,7 +36,16 @@ type Config struct {
 	OpSampleRates map[string]uint32
 }
 
+// ConfigureOnce is used to prevent reinitialization of OpenTelemetry by later arriving configurations
+func ConfigureOnce(cfg *Config) {
+	Configure(cfg)
+	stopReconfiguration = true
+}
+
 func Configure(cfg *Config) {
+	if stopReconfiguration {
+		return
+	}
 	log.Debugf("Configuring OpenTelemetry with sample rate %d and op sample rates %v", cfg.SampleRate, cfg.OpSampleRates)
 	log.Debugf("Connecting to endpoint %v", cfg.Endpoint)
 	log.Debugf("Using headers %v", cfg.Headers)


### PR DESCRIPTION
This PR adds `ConfigureOnce` to otel package, that will configure Otel and make sure any later calls to Configure will be a no-op.
This allows us to initialize otel earlier, with custom options and ignore settings that come from Global config