### PR TITLE
Stop old dialers when we get a new proxy config

### DIFF
--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -41,7 +41,7 @@ func New(opts *Options) Dialer {
 }
 
 // NoDialer returns a dialer that does nothing. This is useful during startup
-// until a real dialer is available.
+// when we don't yet have proxies to dial through.
 func NoDialer() Dialer {
 	return &noDialer{}
 }
@@ -58,6 +58,9 @@ func (d *noDialer) DialContext(ctx context.Context, network, addr string) (net.C
 }
 
 func (d *noDialer) Close() {}
+
+// Make sure noDialer implements Dialer
+var _ Dialer = (*noDialer)(nil)
 
 const (
 	// NetworkConnect is a pseudo network name to instruct the dialer to establish

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/getlantern/golog"
@@ -18,10 +19,16 @@ import (
 
 var log = golog.LoggerFor("dialer")
 
+var currentDialer atomic.Value
+
 // New creates a new dialer that first tries to connect as quickly as possilbe while also
 // optimizing for the fastest dialer.
 func New(opts *Options) Dialer {
-	return NewTwoPhaseDialer(opts, func(opts *Options, existing Dialer) Dialer {
+	if currentDialer.Load() != nil {
+		log.Debug("Closing existing dialer")
+		currentDialer.Load().(Dialer).Close()
+	}
+	d := NewTwoPhaseDialer(opts, func(opts *Options, existing Dialer) Dialer {
 		bandit, err := NewBandit(opts)
 		if err != nil {
 			log.Errorf("Unable to create bandit: %v", err)
@@ -29,6 +36,8 @@ func New(opts *Options) Dialer {
 		}
 		return bandit
 	})
+	currentDialer.Store(d)
+	return d
 }
 
 // NoDialer returns a dialer that does nothing. This is useful during startup
@@ -47,6 +56,8 @@ func (d *noDialer) DialContext(ctx context.Context, network, addr string) (net.C
 	log.Errorf("No dialer available -- should not be called, stack: %s", debug.Stack())
 	return nil, errors.New("no dialer available")
 }
+
+func (d *noDialer) Close() {}
 
 const (
 	// NetworkConnect is a pseudo network name to instruct the dialer to establish
@@ -90,6 +101,9 @@ type Dialer interface {
 
 	// DialContext dials out to the domain or IP address representing a destination site.
 	DialContext(ctx context.Context, network, addr string) (net.Conn, error)
+
+	// Close closes the dialer and cleans up any resources
+	Close()
 }
 
 // hasSucceedingDialer checks whether or not any of the given dialers is able to successfully dial our proxies

--- a/dialer/fastconnect.go
+++ b/dialer/fastconnect.go
@@ -117,8 +117,6 @@ func (fcd *fastConnectDialer) connectAll(dialers []ProxyDialer) {
 		// Loop until we're connected
 		if len(fcd.connected.dialers) < 2 {
 			fcd.parallelDial(dialers)
-			// Add jitter to avoid thundering herd
-			time.Sleep(time.Duration(rand.Intn(4000)) * time.Millisecond)
 		} else {
 			break
 		}
@@ -126,8 +124,7 @@ func (fcd *fastConnectDialer) connectAll(dialers []ProxyDialer) {
 		case <-fcd.stopCh:
 			log.Debug("Stopping parallel dialing")
 			return
-		default:
-
+		case <-time.After(time.Duration(rand.Intn(4000)) * time.Millisecond):
 		}
 	}
 	// At this point, we've tried all of the dialers, and they've all either

--- a/dialer/two_phase_dialer.go
+++ b/dialer/two_phase_dialer.go
@@ -29,7 +29,6 @@ func NewTwoPhaseDialer(opts *Options, next func(opts *Options, existing Dialer) 
 		// This is where we move to the second dialer.
 		nextDialer := next(dialerOpts, existing)
 		tpd.activeDialer.set(nextDialer)
-		existing.Close()
 		return nextDialer
 	})
 


### PR DESCRIPTION
@garmr-ulfr identified a bug in our dialer whereby we keep dialing old dialers when we get a new proxy config. This stops 'em.