### PR TITLE
Draft of creating fronted code early

### DIFF
--- a/chained/broflake_impl.go
+++ b/chained/broflake_impl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getlantern/common/config"
 	"github.com/getlantern/flashlight/v7/ops"
 	"github.com/getlantern/flashlight/v7/proxied"
+	"github.com/getlantern/fronted"
 )
 
 func init() {
@@ -30,10 +31,11 @@ type broflakeImpl struct {
 	ui             *clientcore.UIImpl
 }
 
-func newBroflakeImpl(pc *config.ProxyConfig, reportDialCore reportDialCoreFn) (proxyImpl, error) {
+func newBroflakeImpl(pc *config.ProxyConfig, reportDialCore reportDialCoreFn,
+	fronting fronted.Fronting) (proxyImpl, error) {
 	// TODO: I don't know what the reportDialCoreFn is, and I'm not sure if I need to know. I'm
 	// just imitating the function signature and approach of other impls...
-	bo, wo, qo := makeBroflakeOptions(pc)
+	bo, wo, qo := makeBroflakeOptions(pc, fronting)
 
 	// Construct, init, and start a Broflake client!
 	bfconn, ui, err := clientcore.NewBroflake(bo, wo, nil)
@@ -67,7 +69,7 @@ func (b *broflakeImpl) close() {
 
 // makeBroflakeOptions constructs the options structs required by the Broflake client constructor,
 // overriding fields with values supplied in a ProxyConfig as applicable
-func makeBroflakeOptions(pc *config.ProxyConfig) (
+func makeBroflakeOptions(pc *config.ProxyConfig, fronting fronted.Fronting) (
 	*clientcore.BroflakeOptions,
 	*clientcore.WebRTCOptions,
 	*clientcore.QUICLayerOptions,
@@ -140,8 +142,9 @@ func makeBroflakeOptions(pc *config.ProxyConfig) (
 	// Broflake's HTTP client isn't currently configurable via PluggableTransportSettings, and so
 	// we just give it this domain fronted client in all cases
 	wo.HttpClient = &http.Client{
-		Transport: proxied.Fronted("broflake_fronted_roundtrip", masqueradeTimeout),
-		Timeout:   60 * time.Second,
+		Transport: proxied.Fronted("broflake_fronted_roundtrip",
+			masqueradeTimeout, fronting),
+		Timeout: 60 * time.Second,
 	}
 
 	// Override QUICLayerOptions defaults as applicable

--- a/chained/multipath.go
+++ b/chained/multipath.go
@@ -10,6 +10,7 @@ import (
 	"github.com/getlantern/flashlight/v7/common"
 	"github.com/getlantern/flashlight/v7/dialer"
 	"github.com/getlantern/flashlight/v7/ops"
+	"github.com/getlantern/fronted"
 	"github.com/getlantern/multipath"
 )
 
@@ -49,7 +50,7 @@ func (impl *multipathImpl) FormatStats() []string {
 	return impl.dialer.(multipath.Stats).FormatStats()
 }
 
-func CreateMPDialer(configDir, endpoint string, ss map[string]*config.ProxyConfig, uc common.UserConfig) (dialer.ProxyDialer, error) {
+func CreateMPDialer(configDir, endpoint string, ss map[string]*config.ProxyConfig, uc common.UserConfig, fronting fronted.Fronting) (dialer.ProxyDialer, error) {
 	if len(ss) < 1 {
 		return nil, errors.New("no dialers")
 	}
@@ -68,7 +69,7 @@ func CreateMPDialer(configDir, endpoint string, ss map[string]*config.ProxyConfi
 		if err != nil {
 			return nil, err
 		}
-		impl, err := createImpl(configDir, name, addr, transport, s, uc, p.reportDialCore)
+		impl, err := createImpl(configDir, name, addr, transport, s, uc, p.reportDialCore, fronting)
 		if err != nil {
 			log.Errorf("failed to add %v to %v, continuing: %v", s.Addr, name, err)
 			continue

--- a/chained/proxy_test.go
+++ b/chained/proxy_test.go
@@ -17,7 +17,7 @@ func TestCreateDialersMap(t *testing.T) {
 			Addr: "2.2.2.2", AuthToken: "abcd", Cert: "", PluggableTransport: "https",
 		},
 	}
-	dialers := CreateDialers(tempConfigDir, proxies, newTestUserConfig())
+	dialers := CreateDialers(tempConfigDir, proxies, newTestUserConfig(), mockFronting{})
 	assert.Equal(t, 2, len(dialers))
 	for _, d := range dialers {
 		assert.NotNil(t, d)

--- a/chained/water_impl.go
+++ b/chained/water_impl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/getlantern/common/config"
 	"github.com/getlantern/flashlight/v7/ops"
 	"github.com/getlantern/flashlight/v7/proxied"
+	"github.com/getlantern/fronted"
 	"github.com/refraction-networking/water"
 	_ "github.com/refraction-networking/water/transport/v1"
 )
@@ -30,7 +31,7 @@ type waterImpl struct {
 
 var httpClient *http.Client
 
-func newWaterImpl(dir, addr string, pc *config.ProxyConfig, reportDialCore reportDialCoreFn) (*waterImpl, error) {
+func newWaterImpl(dir, addr string, pc *config.ProxyConfig, reportDialCore reportDialCoreFn, fronting fronted.Fronting) (*waterImpl, error) {
 	ctx := context.Background()
 	wasmAvailableAt := ptSetting(pc, "water_available_at")
 	transport := ptSetting(pc, "water_transport")
@@ -65,7 +66,7 @@ func newWaterImpl(dir, addr string, pc *config.ProxyConfig, reportDialCore repor
 			vc := newWaterVersionControl(dir)
 			cli := httpClient
 			if cli == nil {
-				cli = proxied.ChainedThenDirectThenFrontedClient(1*time.Minute, "")
+				cli = proxied.ChainedThenDirectThenFrontedClient(1*time.Minute, "", fronting)
 			}
 			downloader, err := newWaterWASMDownloader(strings.Split(wasmAvailableAt, ","), cli)
 			if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/getlantern/detour"
 	"github.com/getlantern/errors"
 	"github.com/getlantern/eventual/v2"
+	"github.com/getlantern/fronted"
 	"github.com/getlantern/go-socks5"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/hidden"
@@ -360,9 +361,9 @@ func (client *Client) Connect(dialCtx context.Context, downstreamReader io.Reade
 // Configure updates the client's configuration. Configure can be called
 // before or after ListenAndServe, and can be called multiple times. If
 // no error occurred, then the new dialers are returned.
-func (client *Client) Configure(proxies map[string]*commonconfig.ProxyConfig) []dialer.ProxyDialer {
+func (client *Client) Configure(proxies map[string]*commonconfig.ProxyConfig, fronting fronted.Fronting) []dialer.ProxyDialer {
 	log.Debug("Configure() called")
-	dialers, dialer, err := client.initDialers(proxies)
+	dialers, dialer, err := client.initDialers(proxies, fronting)
 	if err != nil {
 		log.Error(err)
 		return nil
@@ -708,7 +709,7 @@ func errorResponse(_ *filters.ConnectionState, req *http.Request, _ bool, err er
 
 // initDialers takes hosts from cfg.ChainedServers and it uses them to create a
 // new dialer. Returns the new dialers.
-func (client *Client) initDialers(proxies map[string]*commonconfig.ProxyConfig) ([]dialer.ProxyDialer, dialer.Dialer, error) {
+func (client *Client) initDialers(proxies map[string]*commonconfig.ProxyConfig, fronting fronted.Fronting) ([]dialer.ProxyDialer, dialer.Dialer, error) {
 	if len(proxies) == 0 {
 		return nil, nil, fmt.Errorf("no chained servers configured, not initializing dialers")
 	}
@@ -718,7 +719,7 @@ func (client *Client) initDialers(proxies map[string]*commonconfig.ProxyConfig) 
 	}(time.Now())
 	configDir := client.configDir
 	chained.PersistSessionStates(configDir)
-	dialers := chained.CreateDialers(configDir, proxies, client.user)
+	dialers := chained.CreateDialers(configDir, proxies, client.user, fronting)
 	dialer := dialer.New(&dialer.Options{
 		Dialers: dialers,
 		OnError: client.onDialError,

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -12,13 +11,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/getsentry/sentry-go"
 	"gopkg.in/yaml.v3"
 
 	"github.com/getlantern/golog"
 	"github.com/getlantern/rot13"
 
 	"github.com/getlantern/flashlight/v7/common"
+	"github.com/getlantern/flashlight/v7/embeddedconfig"
 	"github.com/getlantern/flashlight/v7/ops"
 )
 
@@ -89,12 +88,6 @@ type options struct {
 	// yaml configs.
 	dispatch func(cfg interface{}, src Source)
 
-	// embeddedData is the data for embedded configs, using tarfs.
-	embeddedData []byte
-
-	// whether or not embedded data is required.
-	embeddedRequired bool
-
 	// sleep the time to sleep between config fetches.
 	sleep func() time.Duration
 
@@ -109,6 +102,51 @@ type options struct {
 
 	// opName is the operation name to use for ops.Begin when fetching configs.
 	opName string
+
+	// ignoreSaved specifies whether or not to ignore saved config and only use
+	// configs fetched from the network (possibly because we previously snagged
+	// the saved config, for example).
+	ignoreSaved bool
+}
+
+func GlobalConfig(configDir string, flags map[string]interface{}) (*Global, error) {
+	configPath := filepath.Join(configDir, "global.yaml")
+	embedded := NewGlobal()
+	if err := yaml.Unmarshal(embeddedconfig.Global, embedded); err != nil {
+		return nil, err
+	}
+	if err := embedded.Validate(); err != nil {
+		return nil, err
+	}
+
+	saved, err := savedGlobal(configPath, obfuscate(flags))
+	if err != nil {
+		return embedded, nil
+	}
+
+	// The embedded config can be newer, for example, if the user has installed a new version of the app.
+	if embeddedIsNewer(configPath) {
+		return embedded, nil
+	} else {
+		return saved, nil
+	}
+}
+
+func savedGlobal(filePath string, obfuscate bool) (*Global, error) {
+	bytes, err := saved(filePath, obfuscate)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("Returning saved global config at %v", filePath)
+	saved := NewGlobal()
+	if err := yaml.Unmarshal(bytes, saved); err != nil {
+		return nil, err
+	}
+	if err := saved.Validate(); err != nil {
+		return nil, err
+	}
+	return saved, nil
 }
 
 // pipeConfig creates a new config pipeline for reading a specified type of
@@ -151,39 +189,16 @@ func pipeConfig(opts *options) (stop func()) {
 	}
 
 	configPath := filepath.Join(opts.saveDir, opts.name)
-
-	log.Tracef("Obfuscating %v", opts.obfuscate)
 	conf := newConfig(configPath, opts)
 
-	sendEmbedded := func() bool {
-		if embedded, err := conf.embedded(opts.embeddedData); err != nil {
-			log.Errorf("Could not load embedded config %v", err)
-			return false
-		} else {
-			log.Debugf("Sending embedded config for %v", opts.name)
-			dispatch(embedded, Embedded)
-			return true
-		}
-	}
-
-	sendSaved := func() bool {
-		if saved, err := conf.saved(); err != nil {
+	// We ignore the saved global config here because we need it so early in the
+	// initialization sequence that we've already grabbed it at this point.
+	if !opts.ignoreSaved {
+		if saved, err := saved(configPath, conf.obfuscate); err != nil {
 			log.Debugf("Could not load stored config %v", err)
-			return false
 		} else {
 			log.Debugf("Sending saved config for %v", opts.name)
 			dispatch(saved, Saved)
-			return true
-		}
-	}
-
-	if embeddedIsNewer(conf, opts) && !opts.sticky {
-		if !sendEmbedded() {
-			sendSaved()
-		}
-	} else {
-		if !sendSaved() {
-			sendEmbedded()
 		}
 	}
 
@@ -207,15 +222,8 @@ func pipeConfig(opts *options) (stop func()) {
 // Checks to see if our embedded config is newer than our saved config. If it is, use that. This could happen,
 // for example, if the user has successfully auto-updated or installed a new version by any means, but
 // where there's some blocking event or bug preventing new configs from being fetched.
-func embeddedIsNewer(conf *config, opts *options) bool {
-	if opts.embeddedData == nil {
-		if opts.embeddedRequired {
-			sentry.CaptureException(log.Errorf("no embedded config for %v", opts.name))
-		}
-		return false
-	}
-
-	saved, err := os.Stat(conf.filePath)
+func embeddedIsNewer(savedPath string) bool {
+	saved, err := os.Stat(savedPath)
 	if os.IsNotExist(err) {
 		return true
 	}
@@ -276,32 +284,33 @@ func newConfig(filePath string, opts *options) *config {
 	return cfg
 }
 
-func (conf *config) saved() (interface{}, error) {
-	infile, err := os.Open(conf.filePath)
+func saved(filePath string, obfuscate bool) ([]byte, error) {
+	infile, err := os.Open(filePath)
 	if err != nil {
-		err = fmt.Errorf("unable to open config file %v for reading: %w", conf.filePath, err)
+		err = fmt.Errorf("unable to open config file %v for reading: %w", filePath, err)
 		log.Error(err.Error())
 		return nil, err
 	}
 	defer infile.Close()
 
 	var in io.Reader = infile
-	if conf.obfuscate {
+	if obfuscate {
 		in = rot13.NewReader(infile)
 	}
 
-	bytes, err := ioutil.ReadAll(in)
+	bytes, err := io.ReadAll(in)
 	if err != nil {
-		err = fmt.Errorf("error reading config from %v: %w", conf.filePath, err)
+		err = fmt.Errorf("error reading config from %v: %w", filePath, err)
 		log.Error(err.Error())
 		return nil, err
 	}
 	if len(bytes) == 0 {
-		return nil, fmt.Errorf("config exists but is empty at %v", conf.filePath)
+		return nil, fmt.Errorf("config exists but is empty at %v", filePath)
 	}
 
-	log.Debugf("Returning saved config at %v", conf.filePath)
-	return conf.unmarshaler(bytes)
+	log.Debugf("Returning saved config at %v", filePath)
+	return bytes, nil
+	//return conf.unmarshaler(bytes)
 }
 
 func (conf *config) embedded(data []byte) (interface{}, error) {

--- a/config/global.go
+++ b/config/global.go
@@ -131,15 +131,11 @@ func (cfg *Global) applyFlags(flags map[string]interface{}) {
 		switch key {
 		case "cloudconfigca":
 			cfg.CloudConfigCA = value.(string)
-		case "borda-report-interval":
-			cfg.BordaReportInterval = value.(time.Duration)
-		case "borda-sample-percentage":
-			cfg.BordaSamplePercentage = value.(float64)
 		}
 	}
 }
 
-func (cfg *Global) validate() error {
+func (cfg *Global) Validate() error {
 	err := cfg.Client.Validate()
 	if err != nil {
 		return err

--- a/config/initializer.go
+++ b/config/initializer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getlantern/yaml"
 
 	"github.com/getlantern/flashlight/v7/common"
-	"github.com/getlantern/flashlight/v7/embeddedconfig"
 )
 
 const packageLogPrefix = "flashlight.config"
@@ -109,16 +108,14 @@ func InitWithURLs(
 
 	// These are the options for fetching the per-user proxy config.
 	proxyOptions := &options{
-		saveDir:          configDir,
-		onSaveError:      onProxiesSaveError,
-		obfuscate:        obfuscate(flags),
-		name:             "proxies.yaml",
-		originURL:        proxyURL,
-		userConfig:       userConfig,
-		unmarshaler:      newProxiesUnmarshaler(),
-		dispatch:         proxiesDispatch,
-		embeddedData:     embeddedconfig.Proxies,
-		embeddedRequired: false,
+		saveDir:     configDir,
+		onSaveError: onProxiesSaveError,
+		obfuscate:   obfuscate(flags),
+		name:        "proxies.yaml",
+		originURL:   proxyURL,
+		userConfig:  userConfig,
+		unmarshaler: newProxiesUnmarshaler(),
+		dispatch:    proxiesDispatch,
 		sleep: func() time.Duration {
 			mx.RLock()
 			defer mx.RUnlock()
@@ -134,24 +131,23 @@ func InitWithURLs(
 
 	// These are the options for fetching the global config.
 	globalOptions := &options{
-		saveDir:          configDir,
-		onSaveError:      onGlobalSaveError,
-		obfuscate:        obfuscate(flags),
-		name:             "global.yaml",
-		originURL:        globalURL,
-		userConfig:       userConfig,
-		unmarshaler:      newGlobalUnmarshaler(flags),
-		dispatch:         globalDispatch,
-		embeddedData:     embeddedconfig.Global,
-		embeddedRequired: true,
+		saveDir:     configDir,
+		onSaveError: onGlobalSaveError,
+		obfuscate:   obfuscate(flags),
+		name:        "global.yaml",
+		originURL:   globalURL,
+		userConfig:  userConfig,
+		unmarshaler: newGlobalUnmarshaler(flags),
+		dispatch:    globalDispatch,
 		sleep: func() time.Duration {
 			mx.RLock()
 			defer mx.RUnlock()
 			return globalConfigPollInterval
 		},
-		sticky: isSticky(flags),
-		rt:     rt,
-		opName: "fetch_global",
+		sticky:      isSticky(flags),
+		rt:          rt,
+		opName:      "fetch_global",
+		ignoreSaved: true,
 	}
 
 	stopGlobal := pipeConfig(globalOptions)
@@ -170,7 +166,7 @@ func newGlobalUnmarshaler(flags map[string]interface{}) func(bytes []byte) (inte
 		if err := yaml.Unmarshal(bytes, gl); err != nil {
 			return nil, err
 		}
-		if err := gl.validate(); err != nil {
+		if err := gl.Validate(); err != nil {
 			return nil, err
 		}
 		return gl, nil

--- a/flashlight.go
+++ b/flashlight.go
@@ -93,6 +93,7 @@ type Flashlight struct {
 	errorHandler     func(HandledErrorType, error)
 	mxProxyListeners sync.RWMutex
 	proxyListeners   []func(map[string]*commonconfig.ProxyConfig, config.Source)
+	fronting         fronted.Fronting
 }
 
 // clientCallbacks are callbacks the client is configured with
@@ -104,13 +105,269 @@ type clientCallbacks struct {
 	onSucceedingProxy func()
 }
 
+// New creates a client proxy.
+func New(
+	appName string,
+	appVersion string,
+	revisionDate string,
+	configDir string,
+	enableVPN bool,
+	disconnected func() bool,
+	_proxyAll func() bool,
+	allowPrivateHosts func() bool,
+	autoReport func() bool,
+	flagsAsMap map[string]interface{},
+	userConfig common.UserConfig,
+	statsTracker stats.Tracker,
+	isPro func() bool,
+	lang func() string,
+	reverseDNS func(host string) (string, error),
+	eventWithLabel func(category, action, label string),
+	options ...Option,
+) (*Flashlight, error) {
+	log.Debugf("Running in app: %v", appName)
+	log.Debugf("Using configdir: %v", configDir)
+	displayVersion(appVersion, revisionDate)
+	common.CompileTimeApplicationVersion = appVersion
+	deviceID := userConfig.GetDeviceID()
+	log.Debugf("You can query for this device's activity under device id: %v", deviceID)
+	fops.InitGlobalContext(appName, appVersion, revisionDate, deviceID, isPro, func() string { return geolookup.GetCountry(0) })
+	email.SetHTTPClient(proxied.DirectThenFrontedClient(1 * time.Minute))
+
+	f := &Flashlight{
+		callbacks: clientCallbacks{
+			onConfigUpdate: func(*config.Global, config.Source) {
+				log.Debug("[Startup] client config updated")
+			},
+			onInit: func() {
+				log.Debug("[Startup] onInit called")
+			},
+			onProxiesUpdate: func(_ []dialer.ProxyDialer, src config.Source) {
+				log.Debugf("[Startup] onProxiesUpdate called from %v", src)
+			},
+			onDialError: func(err error, hasSucceeding bool) {
+
+			},
+			onSucceedingProxy: func() {
+				log.Debug("[Startup] onSucceedingProxy called")
+			},
+		},
+		configDir:  configDir,
+		flagsAsMap: flagsAsMap,
+		userConfig: userConfig,
+		isPro:      isPro,
+		autoReport: autoReport,
+		op:         fops.Begin("client_started"),
+		errorHandler: func(t HandledErrorType, err error) {
+			log.Errorf("%v: %v", t, err)
+		},
+		proxyListeners: make([]func(map[string]*commonconfig.ProxyConfig, config.Source), 0),
+	}
+
+	globalConfig, err := config.GlobalConfig(configDir, flagsAsMap)
+	if err != nil {
+		panic(log.Errorf("unable to load global config: %v", err))
+	}
+	f.global = globalConfig
+	certs, err := globalConfig.TrustedCACerts()
+	if err != nil {
+		log.Errorf("Unable to get trusted ca certs, not configuring fronted: %s", err)
+	}
+
+	f.fronting, err = fronted.NewFronter(certs, globalConfig.Client.FrontedProviders(), config.DefaultFrontedProviderID, filepath.Join(configDir, "masquerade_cache"))
+	if err != nil {
+		log.Errorf("Unable to configure fronted: %v", err)
+	}
+	geolookup.Run(f.fronting)
+
+	f.addProxyListener(func(proxies map[string]*commonconfig.ProxyConfig, src config.Source) {
+		log.Debug("Applying proxy config with proxies")
+		dialers := f.client.Configure(chained.CopyConfigs(proxies))
+		if dialers != nil {
+			f.callbacks.onProxiesUpdate(dialers, src)
+		}
+	})
+
+	var grabber dnsgrab.Server
+	var grabberErr error
+	if enableVPN {
+		grabber, grabberErr = dnsgrab.Listen(50000,
+			"127.0.0.1:53",
+			func() string { return "8.8.8.8" })
+		if grabberErr != nil {
+			log.Errorf("dnsgrab unable to listen: %v", grabberErr)
+		}
+
+		go func() {
+			if err := grabber.Serve(); err != nil {
+				log.Errorf("dnsgrab stopped serving: %v", err)
+			}
+		}()
+
+		reverseDNS = func(addr string) (string, error) {
+			host, port, splitErr := net.SplitHostPort(addr)
+			if splitErr != nil {
+				host = addr
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				log.Debugf("Unable to parse IP %v, passing through address as is", host)
+				return addr, nil
+			}
+			updatedHost, ok := grabber.ReverseLookup(ip)
+			if !ok {
+				// This means that the IP is one of our fake IPs (like 240.0.0.5) but dnsgrab doesn't know it. We cache dnsgrab entries
+				// on disk for 24 hours, so this should almost never happen.
+				return "", errors.New("Invalid IP address")
+			}
+			if splitErr != nil {
+				return updatedHost, nil
+			}
+			return fmt.Sprintf("%v:%v", updatedHost, port), nil
+		}
+	}
+
+	useShortcut := func() bool {
+		return !_proxyAll() && f.featureEnabled(config.FeatureShortcut) && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
+	}
+
+	useDetour := func() bool {
+		return !_proxyAll() && f.featureEnabled(config.FeatureDetour) && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
+	}
+
+	proxyAll := func() bool {
+		useShortcutOrDetour := useShortcut() || useDetour()
+		return !useShortcutOrDetour && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
+	}
+
+	for _, option := range options {
+		option(f)
+	}
+
+	cl, err := client.NewClient(
+		f.configDir,
+		disconnected,
+		proxyAll,
+		useShortcut,
+		shortcut.Allow,
+		useDetour,
+		func() bool {
+			return !f.featureEnabled(config.FeatureNoHTTPSEverywhere)
+		},
+		userConfig,
+		statsTracker,
+		allowPrivateHosts,
+		lang,
+		reverseDNS,
+		eventWithLabel,
+		f.callbacks.onDialError,
+		f.callbacks.onSucceedingProxy,
+	)
+	if err != nil {
+		fatalErr := fmt.Errorf("unable to initialize client: %v", err)
+		f.op.FailIf(fatalErr)
+		f.op.End()
+		return nil, fatalErr
+	}
+	f.client = cl
+	return f, nil
+}
+
+// Run starts background services and runs the client proxy. It blocks as long as
+// the proxy is running.
+func (f *Flashlight) Run(httpProxyAddr, socksProxyAddr string,
+	afterStart func(cl *client.Client),
+	onError func(err error),
+) {
+	stop := f.StartBackgroundServices()
+	defer stop()
+
+	f.RunClientListeners(httpProxyAddr, socksProxyAddr, afterStart, onError)
+}
+
+// Starts background services like config fetching
+func (f *Flashlight) StartBackgroundServices() func() {
+	log.Debug("Starting client proxy background services")
+	// check # of goroutines every minute, print the top 5 stacks with most
+	// goroutines if the # exceeds 800 and is increasing.
+	stopMonitor := goroutines.Monitor(time.Minute, 800, 5)
+
+	stopBypass := bypass.Start(f.addProxyListener, f.configDir, f.userConfig, f.fronting)
+
+	stopConfigFetch := f.startConfigFetch()
+	geolookup.EnablePersistence(filepath.Join(f.configDir, "latestgeoinfo.json"))
+	geolookup.Refresh()
+
+	return func() {
+		stopConfigFetch()
+		stopMonitor()
+		stopBypass()
+	}
+}
+
+// Runs client listeners, blocking as long as the proxy is running.
+func (f *Flashlight) RunClientListeners(httpProxyAddr, socksProxyAddr string,
+	afterStart func(cl *client.Client),
+	onError func(err error),
+) {
+	// Until we know our country, default to IR which has all detection rules
+	log.Debug("Defaulting detour country to IR until real country is known")
+	detour.SetCountry("IR")
+	go func() {
+		country := geolookup.GetCountry(eventual.Forever)
+		log.Debugf("Setting detour country to %v", country)
+		detour.SetCountry(country)
+	}()
+
+	if socksProxyAddr != "" {
+		go func() {
+			log.Debug("Starting client SOCKS5 proxy")
+			err := f.client.ListenAndServeSOCKS5(socksProxyAddr)
+			if err != nil {
+				log.Errorf("Unable to start SOCKS5 proxy: %v", err)
+			}
+		}()
+	}
+
+	if onError == nil {
+		onError = func(_ error) {}
+	}
+	onGeo := geolookup.OnRefresh()
+
+	log.Debug("Starting client HTTP proxy")
+	err := f.client.ListenAndServeHTTP(httpProxyAddr, func() {
+		log.Debug("Started client HTTP proxy")
+		proxied.SetProxyAddr(f.client.Addr)
+		email.SetHTTPClient(proxied.DirectThenFrontedClient(1 * time.Minute))
+
+		ops.Go(func() {
+			// wait for geo info before reporting so that we know the client ip and
+			// country
+			select {
+			case <-onGeo:
+			case <-time.After(5 * time.Minute):
+				log.Debug("failed to get geolocation info within 5 minutes, just record end of startup anyway")
+			}
+			f.op.End()
+		})
+
+		if afterStart != nil {
+			afterStart(f.client)
+		}
+	})
+	if err != nil {
+		log.Errorf("Error running client proxy: %v", err)
+		onError(err)
+	}
+}
+
 func (f *Flashlight) onGlobalConfig(cfg *config.Global, src config.Source) {
 	log.Debugf("Got global config from %v", src)
 	f.mxGlobal.Lock()
 	f.global = cfg
 	f.mxGlobal.Unlock()
 	domainrouting.Configure(cfg.DomainRoutingRules, cfg.ProxiedSites)
-	f.applyClientConfig(cfg)
+	f.applyGlobalConfig(cfg)
 	f.applyOtel(cfg)
 	f.callbacks.onConfigUpdate(cfg, src)
 	f.callbacks.onInit()
@@ -253,9 +510,15 @@ func (f *Flashlight) startConfigFetch() func() {
 	globalDispatch := func(conf interface{}, src config.Source) {
 		cfg := conf.(*config.Global)
 		log.Debugf("Applying global config")
+		certs, err := cfg.TrustedCACerts()
+		if err != nil {
+			log.Errorf("Unable to get trusted ca certs, not configuring fronted: %s", err)
+			return
+		}
+		f.fronting.UpdateConfig(certs, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID)
 		f.onGlobalConfig(cfg, src)
 	}
-	rt := proxied.ParallelPreferChained()
+	rt := proxied.ParallelPreferChained(f.fronting)
 
 	onProxiesSaveError := func(err error) {
 		f.errorHandler(ErrorTypeProxySaveFailure, err)
@@ -277,247 +540,6 @@ func (f *Flashlight) applyOtel(cfg *config.Global) {
 	}
 }
 
-// New creates a client proxy.
-func New(
-	appName string,
-	appVersion string,
-	revisionDate string,
-	configDir string,
-	enableVPN bool,
-	disconnected func() bool,
-	_proxyAll func() bool,
-	allowPrivateHosts func() bool,
-	autoReport func() bool,
-	flagsAsMap map[string]interface{},
-	userConfig common.UserConfig,
-	statsTracker stats.Tracker,
-	isPro func() bool,
-	lang func() string,
-	reverseDNS func(host string) (string, error),
-	eventWithLabel func(category, action, label string),
-	options ...Option,
-) (*Flashlight, error) {
-	log.Debugf("Running in app: %v", appName)
-	log.Debugf("Using configdir: %v", configDir)
-	displayVersion(appVersion, revisionDate)
-	common.CompileTimeApplicationVersion = appVersion
-	deviceID := userConfig.GetDeviceID()
-	log.Debugf("You can query for this device's activity under device id: %v", deviceID)
-	fops.InitGlobalContext(appName, appVersion, revisionDate, deviceID, isPro, func() string { return geolookup.GetCountry(0) })
-	email.SetHTTPClient(proxied.DirectThenFrontedClient(1 * time.Minute))
-
-	f := &Flashlight{
-		callbacks: clientCallbacks{
-			onConfigUpdate: func(*config.Global, config.Source) {
-				log.Debug("[Startup] client config updated")
-			},
-			onInit: func() {
-				log.Debug("[Startup] onInit called")
-			},
-			onProxiesUpdate: func(_ []dialer.ProxyDialer, src config.Source) {
-				log.Debugf("[Startup] onProxiesUpdate called from %v", src)
-			},
-			onDialError: func(err error, hasSucceeding bool) {
-
-			},
-			onSucceedingProxy: func() {
-				log.Debug("[Startup] onSucceedingProxy called")
-			},
-		},
-		configDir:  configDir,
-		flagsAsMap: flagsAsMap,
-		userConfig: userConfig,
-		isPro:      isPro,
-		global:     nil,
-		autoReport: autoReport,
-		op:         fops.Begin("client_started"),
-		errorHandler: func(t HandledErrorType, err error) {
-			log.Errorf("%v: %v", t, err)
-		},
-		proxyListeners: make([]func(map[string]*commonconfig.ProxyConfig, config.Source), 0),
-	}
-
-	f.addProxyListener(func(proxies map[string]*commonconfig.ProxyConfig, src config.Source) {
-		log.Debug("Applying proxy config with proxies")
-		dialers := f.client.Configure(chained.CopyConfigs(proxies))
-		if dialers != nil {
-			f.callbacks.onProxiesUpdate(dialers, src)
-		}
-	})
-
-	var grabber dnsgrab.Server
-	var grabberErr error
-	if enableVPN {
-		grabber, grabberErr = dnsgrab.Listen(50000,
-			"127.0.0.1:53",
-			func() string { return "8.8.8.8" })
-		if grabberErr != nil {
-			log.Errorf("dnsgrab unable to listen: %v", grabberErr)
-		}
-
-		go func() {
-			if err := grabber.Serve(); err != nil {
-				log.Errorf("dnsgrab stopped serving: %v", err)
-			}
-		}()
-
-		reverseDNS = func(addr string) (string, error) {
-			host, port, splitErr := net.SplitHostPort(addr)
-			if splitErr != nil {
-				host = addr
-			}
-			ip := net.ParseIP(host)
-			if ip == nil {
-				log.Debugf("Unable to parse IP %v, passing through address as is", host)
-				return addr, nil
-			}
-			updatedHost, ok := grabber.ReverseLookup(ip)
-			if !ok {
-				// This means that the IP is one of our fake IPs (like 240.0.0.5) but dnsgrab doesn't know it. We cache dnsgrab entries
-				// on disk for 24 hours, so this should almost never happen.
-				return "", errors.New("Invalid IP address")
-			}
-			if splitErr != nil {
-				return updatedHost, nil
-			}
-			return fmt.Sprintf("%v:%v", updatedHost, port), nil
-		}
-	}
-
-	useShortcut := func() bool {
-		return !_proxyAll() && f.featureEnabled(config.FeatureShortcut) && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
-	}
-
-	useDetour := func() bool {
-		return !_proxyAll() && f.featureEnabled(config.FeatureDetour) && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
-	}
-
-	proxyAll := func() bool {
-		useShortcutOrDetour := useShortcut() || useDetour()
-		return !useShortcutOrDetour && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
-	}
-
-	for _, option := range options {
-		option(f)
-	}
-
-	cl, err := client.NewClient(
-		f.configDir,
-		disconnected,
-		proxyAll,
-		useShortcut,
-		shortcut.Allow,
-		useDetour,
-		func() bool {
-			return !f.featureEnabled(config.FeatureNoHTTPSEverywhere)
-		},
-		userConfig,
-		statsTracker,
-		allowPrivateHosts,
-		lang,
-		reverseDNS,
-		eventWithLabel,
-		f.callbacks.onDialError,
-		f.callbacks.onSucceedingProxy,
-	)
-	if err != nil {
-		fatalErr := fmt.Errorf("unable to initialize client: %v", err)
-		f.op.FailIf(fatalErr)
-		f.op.End()
-		return nil, fatalErr
-	}
-	f.client = cl
-	return f, nil
-}
-
-// Run starts background services and runs the client proxy. It blocks as long as
-// the proxy is running.
-func (f *Flashlight) Run(httpProxyAddr, socksProxyAddr string,
-	afterStart func(cl *client.Client),
-	onError func(err error),
-) {
-	stop := f.StartBackgroundServices()
-	defer stop()
-
-	f.RunClientListeners(httpProxyAddr, socksProxyAddr, afterStart, onError)
-}
-
-// Starts background services like config fetching
-func (f *Flashlight) StartBackgroundServices() func() {
-	log.Debug("Starting client proxy background services")
-	// check # of goroutines every minute, print the top 5 stacks with most
-	// goroutines if the # exceeds 800 and is increasing.
-	stopMonitor := goroutines.Monitor(time.Minute, 800, 5)
-
-	stopBypass := bypass.Start(f.addProxyListener, f.configDir, f.userConfig)
-
-	stopConfigFetch := f.startConfigFetch()
-	geolookup.EnablePersistence(filepath.Join(f.configDir, "latestgeoinfo.json"))
-	geolookup.Refresh()
-
-	return func() {
-		stopConfigFetch()
-		stopMonitor()
-		stopBypass()
-	}
-}
-
-// Runs client listeners, blocking as long as the proxy is running.
-func (f *Flashlight) RunClientListeners(httpProxyAddr, socksProxyAddr string,
-	afterStart func(cl *client.Client),
-	onError func(err error),
-) {
-	// Until we know our country, default to IR which has all detection rules
-	log.Debug("Defaulting detour country to IR until real country is known")
-	detour.SetCountry("IR")
-	go func() {
-		country := geolookup.GetCountry(eventual.Forever)
-		log.Debugf("Setting detour country to %v", country)
-		detour.SetCountry(country)
-	}()
-
-	if socksProxyAddr != "" {
-		go func() {
-			log.Debug("Starting client SOCKS5 proxy")
-			err := f.client.ListenAndServeSOCKS5(socksProxyAddr)
-			if err != nil {
-				log.Errorf("Unable to start SOCKS5 proxy: %v", err)
-			}
-		}()
-	}
-
-	if onError == nil {
-		onError = func(_ error) {}
-	}
-	onGeo := geolookup.OnRefresh()
-
-	log.Debug("Starting client HTTP proxy")
-	err := f.client.ListenAndServeHTTP(httpProxyAddr, func() {
-		log.Debug("Started client HTTP proxy")
-		proxied.SetProxyAddr(f.client.Addr)
-		email.SetHTTPClient(proxied.DirectThenFrontedClient(1 * time.Minute))
-
-		ops.Go(func() {
-			// wait for geo info before reporting so that we know the client ip and
-			// country
-			select {
-			case <-onGeo:
-			case <-time.After(5 * time.Minute):
-				log.Debug("failed to get geolocation info within 5 minutes, just record end of startup anyway")
-			}
-			f.op.End()
-		})
-
-		if afterStart != nil {
-			afterStart(f.client)
-		}
-	})
-	if err != nil {
-		log.Errorf("Error running client proxy: %v", err)
-		onError(err)
-	}
-}
-
 // SetErrorHandler configures error handling. All errors provided to the handler are significant,
 // but not enough to stop operation of the Flashlight instance. This method must be called before
 // calling Run. All errors provided to the handler will be of a HandledErrorType defined in this
@@ -536,13 +558,13 @@ func (f *Flashlight) Stop() error {
 	return f.client.Stop()
 }
 
-func (f *Flashlight) applyClientConfig(cfg *config.Global) {
+func (f *Flashlight) applyGlobalConfig(cfg *config.Global) {
 	f.client.DNSResolutionMapForDirectDialsEventual.Set(cfg.Client.DNSResolutionMapForDirectDials)
 	certs, err := cfg.TrustedCACerts()
 	if err != nil {
 		log.Errorf("Unable to get trusted ca certs, not configuring fronted: %s", err)
 	} else if cfg.Client != nil && cfg.Client.Fronted != nil {
-		fronted.Configure(certs, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID, filepath.Join(f.configDir, "masquerade_cache"))
+		f.fronting.UpdateConfig(certs, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID)
 	} else {
 		log.Errorf("Unable to configured fronted (no config)")
 	}

--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -1,7 +1,6 @@
 package issue
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,7 +22,7 @@ func TestMain(m *testing.M) {
 	defer os.RemoveAll(tempConfigDir)
 
 	// Init domain-fronting
-	global, err := ioutil.ReadFile("../embeddedconfig/global.yaml")
+	global, err := os.ReadFile("../embeddedconfig/global.yaml")
 	if err != nil {
 		log.Errorf("Unable to load embedded global config: %v", err)
 		os.Exit(1)
@@ -39,7 +38,7 @@ func TestMain(m *testing.M) {
 		log.Errorf("Unable to read trusted certs: %v", err)
 	}
 	log.Debug(cfg.Client.FrontedProviders())
-	fronted.Configure(certs, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID, filepath.Join(tempConfigDir, "masquerade_cache"))
+	fronted.NewFronter(certs, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID, filepath.Join(tempConfigDir, "masquerade_cache"))
 
 	// Perform initial geolookup with a high timeout so that we don't later timeout when trying to
 	geolookup.Refresh()


### PR DESCRIPTION
This is based on the pre-consolidated request code, so this is more of a placeholder for now. The idea is that we need to more explicitly create the global config based on the embedded or saved config right away on startup so we can begin finding working domain fronts. The current code quickly gets a new global global config from the network, which aborts any prior work that had been done in `fronted` to establish working fronts. Often the victim of this is the most essential request for the initial proxy fetch, which is of course completely different with consolidated requests.