### PR TITLE
dial proxied if both shortcut and detour are disabled

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -568,7 +568,7 @@ func (client *Client) doDial(op *ops.Op, ctx context.Context, isCONNECT bool, ad
 	} else if !client.useShortcut() {
 		dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			log.Tracef("Dialing %v directly because neither detour nor shortcut is enabled", addr)
-			return dialDirect(ctx, network, addr)
+			return dialProxied(ctx, network, addr)
 		}
 	} else {
 		dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {


### PR DESCRIPTION
This is that change to switch from dialDirect to dialProxied when shortcut and detour are disabled @hwh33 and @garmr-ulfr.

Not sure how this code has...ever worked. This changes the default behavior to dial via a proxy vs directly.