### PR TITLE
#1757 Upgrade tlsdialer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9
 	github.com/getlantern/tinywss v0.0.0-20211216020538-c10008a7d461
 	github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4
-	github.com/getlantern/tlsdialer/v3 v3.0.4
+	github.com/getlantern/tlsdialer/v3 v3.0.5
 	github.com/getlantern/tlsmasq v0.4.7-0.20230302000139-6e479a593298
 	github.com/getlantern/tlsresumption v0.0.0-20241210052744-a1c6aacc1d4d
 	github.com/getlantern/tlsutil v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/getlantern/tinywss v0.0.0-20211216020538-c10008a7d461 h1:3HOWV/uUGde6
 github.com/getlantern/tinywss v0.0.0-20211216020538-c10008a7d461/go.mod h1:ZLyPOKtNWU4vWnAiRiNQ7hbfLMqCEuj1DgQWBtHp7tQ=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4 h1:73U3J4msGw3cXeKtCEbY7hbOdD6aX8gJv8BOu+VagF8=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4/go.mod h1:f8WmDYKFOaC5/y0d3GWl6UKf1ZbSlIoMzkuC8x7pUhg=
-github.com/getlantern/tlsdialer/v3 v3.0.4 h1:j9GHqtD2+cwGP/q+Rvr/wC43nPrRPk6YfEmWfZJ4p1I=
-github.com/getlantern/tlsdialer/v3 v3.0.4/go.mod h1:G0rWRzTX9WuQ0r31c/Zg9sfwTrMs82kyQCswlhwv/Us=
+github.com/getlantern/tlsdialer/v3 v3.0.5 h1:xdLBQDgz0PXLK6T27hjtZU25MyucRiUKj58aqyQZvP4=
+github.com/getlantern/tlsdialer/v3 v3.0.5/go.mod h1:aXHS9CXIzgsdHwlTcFmmPzFbw0l6QBLxkCdSCmclqDI=
 github.com/getlantern/tlsmasq v0.4.7-0.20230302000139-6e479a593298 h1:GxhCQ6zLnIeaIw2gtZsM7hSlpXHdd8DoXSEPObSHMuk=
 github.com/getlantern/tlsmasq v0.4.7-0.20230302000139-6e479a593298/go.mod h1:vcDVZe3TGEqd0nD0tVvqKoyGHY+5bPxCa+IklxroKd0=
 github.com/getlantern/tlsresumption v0.0.0-20241210052744-a1c6aacc1d4d h1:CM+1DbLVMvsrf5cvQnPF2txKKRI1H2sDj0+WvDrZ6zU=


### PR DESCRIPTION
* https://github.com/getlantern/engineering/issues/1757
* To fix the checksum error due to reuse v3.0.4 tag