### PR TITLE
Make proxied and fronting code self-contained to avoid platform-specific errors

### DIFF
--- a/config/client_config.go
+++ b/config/client_config.go
@@ -8,12 +8,6 @@ import (
 	"github.com/getlantern/fronted"
 )
 
-const (
-	// for historical reasons, if a provider is unspecified in a masquerade, it
-	// is treated as a cloudfront masquerade (which was once the only provider)
-	DefaultFrontedProviderID = "cloudfront"
-)
-
 // ClientConfig captures configuration information for a Client
 type ClientConfig struct {
 	DumpHeaders bool // whether or not to dump headers of requests and responses

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/keighl/mandrill"
-	tls "github.com/refraction-networking/utls"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/getlantern/flashlight/v7/config"
 	"github.com/getlantern/flashlight/v7/proxied"
-	"github.com/getlantern/fronted"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/yaml"
 )
@@ -59,7 +56,7 @@ func TestSubmitIssue(t *testing.T) {
 	// test that domain-fronting is working, you can block mandrillapp.com, for
 	// example by setting its address to 0.0.0.0 in /etc/hosts.
 	if false {
-		proxied.SetFronted(newFronted())
+		updateFronted()
 
 		msg := &Message{
 			To:       "ox+unittest@getlantern.org",
@@ -70,7 +67,7 @@ func TestSubmitIssue(t *testing.T) {
 	}
 }
 
-func newFronted() fronted.Fronted {
+func updateFronted() {
 	// Init domain-fronting
 	global, err := os.ReadFile("../embeddedconfig/global.yaml")
 	if err != nil {
@@ -95,10 +92,5 @@ func newFronted() fronted.Fronted {
 		os.Exit(1)
 	}
 	defer os.RemoveAll(tempConfigDir)
-	fronted, err := fronted.NewFronted(filepath.Join(tempConfigDir, "masquerade_cache"), tls.HelloChrome_100, config.DefaultFrontedProviderID)
-	if err != nil {
-		log.Errorf("Unable to configure fronted: %v", err)
-	}
-	fronted.UpdateConfig(certs, cfg.Client.FrontedProviders())
-	return fronted
+	proxied.OnNewFronts(certs, cfg.Client.FrontedProviders())
 }

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/getlantern/event v0.0.0-20210901195647-a7e3145142e6
 	github.com/getlantern/eventual v1.0.0
 	github.com/getlantern/eventual/v2 v2.0.2
-	github.com/getlantern/fronted v0.0.0-20241210170228-72225de4ec5a
+	github.com/getlantern/fronted v0.0.0-20241212194832-a55b6db2616e
 	github.com/getlantern/go-socks5 v0.0.0-20171114193258-79d4dd3e2db5
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/hellosplitter v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c h1:mcz27xtA
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
 github.com/getlantern/framed v0.0.0-20190601192238-ceb6431eeede h1:yrU6Px3ZkvCsDLPryPGi6FN+2iqFPq+JeCb7EFoDBhw=
 github.com/getlantern/framed v0.0.0-20190601192238-ceb6431eeede/go.mod h1:nhnoiS6DE6zfe+BaCMU4YI01UpsuiXnDqM5S8jxHuuI=
-github.com/getlantern/fronted v0.0.0-20241210170228-72225de4ec5a h1:L+tVpvLMJvX/NwbVcKb4L7nPOf8X9bccaYp/0Duy2xU=
-github.com/getlantern/fronted v0.0.0-20241210170228-72225de4ec5a/go.mod h1:UOynqDcVIlDMFk3sdUyHzNyY1cz4GHtJ+8qvWESHWhg=
+github.com/getlantern/fronted v0.0.0-20241212194832-a55b6db2616e h1:qk62Xhg+ha1sW6FhOmGPGbd3xnCC5n9Mr87vDToE0cM=
+github.com/getlantern/fronted v0.0.0-20241212194832-a55b6db2616e/go.mod h1:UOynqDcVIlDMFk3sdUyHzNyY1cz4GHtJ+8qvWESHWhg=
 github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e h1:vpikNz6IzvEoqVYmiK5Uq+lE4TCzvMDqbZdxFbtGK1g=
 github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e/go.mod h1:RjQ0krF8NTCc5xo2Q1995/vZBnYg33h8svn15do7dLg=
 github.com/getlantern/go-socks5 v0.0.0-20171114193258-79d4dd3e2db5 h1:RBKofGGMt2k6eGBwX8mky9qunjL+KnAp9JdzXjiRkRw=

--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -2,14 +2,10 @@ package issue
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"gopkg.in/yaml.v2"
-
-	"github.com/getlantern/fronted"
-	tls "github.com/refraction-networking/utls"
 
 	"github.com/getlantern/flashlight/v7/config"
 	"github.com/getlantern/flashlight/v7/geolookup"
@@ -18,8 +14,7 @@ import (
 
 func TestMain(m *testing.M) {
 
-	fronted := newFronted()
-	proxied.SetFronted(fronted)
+	updateFronted()
 
 	//log.Debug(cfg.Client.FrontedProviders())
 	//fronted.Configure(certs, cfg.Client.FrontedProviders(), config.DefaultFrontedProviderID, filepath.Join(tempConfigDir, "masquerade_cache"))
@@ -28,7 +23,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newFronted() fronted.Fronted {
+func updateFronted() {
 	// Init domain-fronting
 	global, err := os.ReadFile("../embeddedconfig/global.yaml")
 	if err != nil {
@@ -53,17 +48,11 @@ func newFronted() fronted.Fronted {
 		os.Exit(1)
 	}
 	defer os.RemoveAll(tempConfigDir)
-	fronted, err := fronted.NewFronted(filepath.Join(tempConfigDir, "masquerade_cache"), tls.HelloChrome_100, config.DefaultFrontedProviderID)
-	if err != nil {
-		log.Errorf("Unable to configure fronted: %v", err)
-	}
-	fronted.UpdateConfig(certs, cfg.Client.FrontedProviders())
-	return fronted
+	proxied.OnNewFronts(certs, cfg.Client.FrontedProviders())
 }
 
 func TestSendReport(t *testing.T) {
-	fronted := newFronted()
-	proxied.SetFronted(fronted)
+	updateFronted()
 	err := sendReport(
 		"34qsdf-24qsadf-32542q",
 		"1",

--- a/proxied/fronted.go
+++ b/proxied/fronted.go
@@ -1,10 +1,28 @@
 package proxied
 
 import (
+	"crypto/x509"
 	"net/http"
+	"os"
+	"path/filepath"
 
+	"github.com/getlantern/flashlight/v7/common"
 	"github.com/getlantern/flashlight/v7/ops"
+	"github.com/getlantern/fronted"
 )
+
+var fronter fronted.Fronted = newFronted()
+
+func newFronted() fronted.Fronted {
+	var cacheFile string
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		log.Errorf("Unable to get user config dir: %v", err)
+	} else {
+		cacheFile = filepath.Join(dir, common.DefaultAppName, "fronted_cache.json")
+	}
+	return fronted.NewFronted(cacheFile)
+}
 
 // Fronted creates an http.RoundTripper that proxies request using domain
 // fronting.
@@ -27,4 +45,9 @@ func (f frontedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 		defer op.End()
 	}
 	return fronter.RoundTrip(req)
+}
+
+// OnNewFronts updates the fronted configuration with the new fronted providers.
+func OnNewFronts(pool *x509.CertPool, providers map[string]*fronted.Provider) {
+	fronter.OnNewFronts(pool, providers)
 }

--- a/proxied/proxied.go
+++ b/proxied/proxied.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/getlantern/errors"
 	"github.com/getlantern/eventual"
-	"github.com/getlantern/fronted"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/keyman"
 	"github.com/getlantern/netx"
@@ -47,18 +46,7 @@ var (
 
 	// Shared client session cache for all connections
 	clientSessionCache = tls.NewLRUClientSessionCache(1000)
-
-	fronter   fronted.Fronted
-	fronterMu sync.RWMutex
 )
-
-// SetFronted sets the fronted.Fronted to use for domain fronting. This is a bit hacky but otherwise would
-// require a significant refactor of the proxied package.
-func SetFronted(f fronted.Fronted) {
-	fronterMu.Lock()
-	fronter = f
-	fronterMu.Unlock()
-}
 
 func success(resp *http.Response) bool {
 	return (resp.StatusCode > 199 && resp.StatusCode < 400) || resp.StatusCode == http.StatusUpgradeRequired

--- a/proxied/proxied_test.go
+++ b/proxied/proxied_test.go
@@ -164,7 +164,7 @@ func TestSwitchingToChained(t *testing.T) {
 }
 
 func doTestChainedAndFronted(t *testing.T, build func() http.RoundTripper) {
-	updateFronted()
+	//updateFronted()
 	fwd, _ := forward.New()
 
 	sleep := 0 * time.Second

--- a/proxied/testutils.go
+++ b/proxied/testutils.go
@@ -51,33 +51,6 @@ func (c *mockRoundTripper_FailOnceAndThenReturn200) RoundTrip(
 	return resp, nil
 }
 
-type mockRoundTripper_Return200Once struct {
-	id             FlowComponentID
-	processingTime time.Duration
-	return200After int
-	currentCount   int
-}
-
-// RoundTrip here just sleeps a bit and then returns 200 OK.
-// The request is not processed at all
-func (c *mockRoundTripper_Return200Once) RoundTrip(
-	*http.Request,
-) (*http.Response, error) {
-	time.Sleep(c.processingTime)
-	resp := &http.Response{
-		Header: map[string][]string{
-			roundTripperHeaderKey: []string{c.id.String()},
-		},
-	}
-	if c.currentCount == c.return200After {
-		resp.StatusCode = 200
-	} else {
-		resp.StatusCode = 400
-	}
-	c.currentCount++
-	return resp, nil
-}
-
 type mockRoundTripper_Return400 struct {
 	id             FlowComponentID
 	processingTime time.Duration


### PR DESCRIPTION
We've been having issues with initializing the `proxied` package consistently for all platforms. iOS, for example, does not call `flashlight.New`, and, as a result, the `fronter` responsible for domain fronting code in the `proxied` package was never set. This change is more accommodating of heterogeneous initialization environments with the goal of ensuring fronting works as expected for all users.