### PR TITLE
Report Issue fix

### DIFF
--- a/issue/issue.go
+++ b/issue/issue.go
@@ -42,6 +42,7 @@ func SendReport(
 	model string, // alphanumeric name
 	osVersion string,
 	attachments []*Attachment,
+	country string,
 ) (err error) {
 	return sendReport(
 		userConfig.GetDeviceID(),
@@ -57,6 +58,7 @@ func SendReport(
 		model,
 		osVersion,
 		attachments,
+		country,
 	)
 }
 
@@ -74,6 +76,7 @@ func sendReport(
 	model string,
 	osVersion string,
 	attachments []*Attachment,
+	country string,
 ) error {
 	httpClient := &http.Client{
 		Transport: proxied.Fronted("issue_fronted_roundtrip"),
@@ -81,7 +84,12 @@ func sendReport(
 	r := &Request{}
 
 	r.Type = Request_ISSUE_TYPE(issueType)
-	r.CountryCode = geolookup.GetCountry(5 * time.Second)
+	if country == "" {
+		r.CountryCode = geolookup.GetCountry(5 * time.Second)
+	} else {
+		// This is temp due to IOS still uses the old geolookup
+		r.CountryCode = country
+	}
 	r.AppVersion = appVersion
 	r.SubscriptionLevel = subscriptionLevel
 	r.Platform = common.Platform

--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -72,6 +72,7 @@ func TestSendReport(t *testing.T) {
 				Data: []byte("Hello World"),
 			},
 		},
+		"US",
 	)
 	if err != nil {
 		t.Errorf("SendReport() error = %v", err)


### PR DESCRIPTION
This PR passes the country to report the issue for IOS, this is needed due to report issue using the new geoLookup API for getting the country, and for IOS we are still using the old geo lookup