### PR TITLE
reduced the number of init() calls and references to staging

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -12,9 +12,6 @@ const (
 	// UserConfigURL is the URL for fetching the per user proxy config.
 	UserConfigURL = "http://df.iantem.io/api/v1/config"
 
-	// UserConfigStagingURL is the URL for fetching the per user proxy config in a staging environment.
-	UserConfigStagingURL = "https://api-staging.iantem.io/config"
-
 	// Sentry Configurations
 	SentryTimeout         = time.Second * 30
 	SentryMaxMessageChars = 8000
@@ -33,50 +30,16 @@ var (
 	// GlobalURL URL for fetching the global config.
 	GlobalURL = "https://globalconfig.flashlightproxy.com/global.yaml.gz"
 
-	// GlobalStagingURL is the URL for fetching the global config in a staging environment.
-	GlobalStagingURL = "https://globalconfig.flashlightproxy.com/global.yaml.gz"
-
-	// StagingMode if true, run Lantern against our staging infrastructure.
-	// This is set by the linker using -ldflags
-	StagingMode = "false"
-
-	Staging = false
-
 	ProAPIHost = "api.getiantem.org"
 
 	log = golog.LoggerFor("flashlight.common")
-
-	forceAds bool
 
 	// Set by the linker using -ldflags in the project's Makefile.
 	// Defaults to 'production' so as not to mistakingly push development work
 	// to a production environment
 	Environment = "production"
 )
-
-func init() {
-	initInternal()
-}
-
-// ForceStaging forces staging mode.
-func ForceStaging() {
-	StagingMode = "true"
-	initInternal()
-}
-
-func initInternal() {
-	var err error
-	log.Debugf("****************************** stagingMode: %v", StagingMode)
-	Staging, err = strconv.ParseBool(StagingMode)
-	if err != nil {
-		log.Errorf("Error parsing boolean flag: %v", err)
-		return
-	}
-	if Staging {
-		ProAPIHost = "api-staging.getiantem.org"
-	}
-	forceAds, _ = strconv.ParseBool(os.Getenv("FORCEADS"))
-}
+var forceAds, _ = strconv.ParseBool(os.Getenv("FORCEADS"))
 
 // ForceAds indicates whether adswapping should be forced to 100%
 func ForceAds() bool {

--- a/common/const.go
+++ b/common/const.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/getlantern/golog"
@@ -39,9 +37,3 @@ var (
 	// to a production environment
 	Environment = "production"
 )
-var forceAds, _ = strconv.ParseBool(os.Getenv("FORCEADS"))
-
-// ForceAds indicates whether adswapping should be forced to 100%
-func ForceAds() bool {
-	return forceAds
-}

--- a/common/version.go
+++ b/common/version.go
@@ -15,7 +15,8 @@ var (
 	LibraryVersion = ""
 )
 
-func init() {
+func InitVersion(compileTimeApplicationVersion string) {
+	CompileTimeApplicationVersion = compileTimeApplicationVersion
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
 		panic("Unable to read build info")

--- a/config/fetcher_test.go
+++ b/config/fetcher_test.go
@@ -25,25 +25,3 @@ func TestFetcher(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, len(bytes) > 200)
 }
-
-// TestStagingSetup tests to make sure our staging config flag sets the
-// appropriate URLs for staging servers.
-func TestStagingSetup(t *testing.T) {
-	flags := make(map[string]interface{})
-	flags["staging"] = false
-
-	rt := &http.Transport{}
-
-	var fetch *fetcher
-	fetch = newHttpFetcher(newTestUserConfig(), rt, common.UserConfigURL).(*fetcher)
-	assert.Equal(t, common.UserConfigURL, fetch.originURL)
-
-	// Blank flags should mean we use the default
-	flags["cloudconfig"] = ""
-	fetch = newHttpFetcher(newTestUserConfig(), rt, common.UserConfigURL).(*fetcher)
-	assert.Equal(t, common.UserConfigURL, fetch.originURL)
-
-	flags["staging"] = true
-	fetch = newHttpFetcher(newTestUserConfig(), rt, common.UserConfigStagingURL).(*fetcher)
-	assert.Equal(t, common.UserConfigStagingURL, fetch.originURL)
-}

--- a/config/initializer.go
+++ b/config/initializer.go
@@ -28,8 +28,7 @@ func Init(
 	origGlobalDispatch func(interface{}, Source), onGlobalSaveError func(error),
 	rt http.RoundTripper) (stop func()) {
 
-	staging := isStaging(flags)
-	globalConfigURL := checkOverrides(flags, getGlobalURL(staging), "global.yaml.gz")
+	globalConfigURL := checkOverrides(flags, common.GlobalURL, "global.yaml.gz")
 
 	return InitWithURLs(
 		configDir, flags, userConfig,
@@ -124,10 +123,6 @@ func obfuscate(flags map[string]interface{}) bool {
 	return flags["readableconfig"] == nil || !flags["readableconfig"].(bool)
 }
 
-func isStaging(flags map[string]interface{}) bool {
-	return checkBool(flags, "staging")
-}
-
 func isSticky(flags map[string]interface{}) bool {
 	return checkBool(flags, "stickyconfig")
 }
@@ -148,15 +143,4 @@ func checkOverrides(flags map[string]interface{},
 		}
 	}
 	return url
-}
-
-// getGlobalURL returns the global URL to use depending on whether or not
-// we're in staging.
-func getGlobalURL(staging bool) string {
-	if staging {
-		log.Debug("Will obtain global.yaml from staging service")
-		return common.GlobalStagingURL
-	}
-	log.Debugf("Will obtain global.yaml from production service at %v", common.GlobalURL)
-	return common.GlobalURL
 }

--- a/config/initializer_test.go
+++ b/config/initializer_test.go
@@ -20,7 +20,6 @@ func TestInit(t *testing.T) {
 	defer deleteGlobalConfig()
 
 	flags := make(map[string]interface{})
-	flags["staging"] = true
 
 	gotProxies := eventual.NewValue()
 	gotGlobal := eventual.NewValue()
@@ -35,8 +34,6 @@ func TestInit(t *testing.T) {
 	stop := Init(
 		".", flags, newTestUserConfig(), globalDispatch, nil, &http.Transport{
 			Proxy: func(req *http.Request) (*url.URL, error) {
-				// the same token should also be configured on staging
-				// config-server, staging proxies and staging DDF distributions.
 				req.Header.Add(common.CfgSvrAuthTokenHeader, "staging-token")
 				return nil, nil
 			},
@@ -71,7 +68,6 @@ func TestInitWithURLs(t *testing.T) {
 
 		// set up and call InitWithURLs
 		flags := make(map[string]interface{})
-		flags["staging"] = true
 
 		globalDispatch := func(interface{}, Source) {}
 		stop := InitWithURLs(
@@ -90,17 +86,6 @@ func TestInitWithURLs(t *testing.T) {
 		// test that proxy & config servers were called the correct number of times
 		assert.GreaterOrEqual(t, 3, int(globalReqCount()), "should have fetched global config every %v", globalConfig.GlobalConfigPollInterval)
 	})
-}
-
-func TestStaging(t *testing.T) {
-	flags := make(map[string]interface{})
-	flags["staging"] = true
-
-	assert.True(t, isStaging(flags))
-
-	flags["staging"] = false
-
-	assert.False(t, isStaging(flags))
 }
 
 // TestOverrides tests url override flags

--- a/flags.go
+++ b/flags.go
@@ -40,7 +40,6 @@ type Flags struct {
 	Initialize         bool          `flag:"initialize" help:"silently initialize Lantern to a state of having working proxy and exit, typically during installation."`
 	Timeout            time.Duration `flag:"timeout" help:"force stop Lantern with an exit status of -1 after the timeout."`
 	ReplicaRustUrl     string        `flag:"replica-rust-url" help:"use the replica-rust service at the provided endpoint"`
-	Staging            bool          `flag:"-"`
 	Experiments        []string      `flag:"enabled-experiments" help:"comma separated list of experiments to enable"`
 }
 

--- a/pro/client/client_test.go
+++ b/pro/client/client_test.go
@@ -104,10 +104,6 @@ func generateUser() *common.UserConfigData {
 	return common.NewUserConfigData(common.DefaultAppName, generateDeviceId(), int64(rand.Uint64()), fmt.Sprintf("aasfge%d", rand.Uint64()), nil, "en-US")
 }
 
-func init() {
-	common.ForceStaging()
-}
-
 func createClient(resp *http.Response) *Client {
 	mockedHTTPClient := createMockClient(resp)
 	return NewClient(mockedHTTPClient, func(req *http.Request, uc common.UserConfig) {

--- a/pro/user_data_test.go
+++ b/pro/user_data_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestUsers(t *testing.T) {
-	common.ForceStaging()
-
 	deviceID := "77777777"
 	userID := int64(1000)
 	token := uuid.NewString()

--- a/proxied/fronted.go
+++ b/proxied/fronted.go
@@ -11,20 +11,20 @@ import (
 	"github.com/getlantern/fronted"
 )
 
-var fronter fronted.Fronted = newFronted()
+var fronter fronted.Fronted
 
-func newFronted() fronted.Fronted {
+func InitFronted() fronted.Fronted {
 	var cacheFile string
 	dir, err := os.UserConfigDir()
 	if err != nil {
-		log.Errorf("Unable to get user config dir: %v", err)
+		_ = log.Errorf("Unable to get user config dir: %v", err)
 	} else {
 		cacheFile = filepath.Join(dir, common.DefaultAppName, "fronted_cache.json")
 	}
 	return fronted.NewFronted(cacheFile)
 }
 
-// Fronted creates an http.RoundTripper that proxies request using domain
+// Fronted creates a http.RoundTripper that proxies request using domain
 // fronting.
 func Fronted(opName string) http.RoundTripper {
 	return frontedRoundTripper{

--- a/proxied/fronted.go
+++ b/proxied/fronted.go
@@ -21,7 +21,8 @@ func InitFronted() fronted.Fronted {
 	} else {
 		cacheFile = filepath.Join(dir, common.DefaultAppName, "fronted_cache.json")
 	}
-	return fronted.NewFronted(cacheFile)
+	fronter = fronted.NewFronted(cacheFile)
+	return fronter
 }
 
 // Fronted creates a http.RoundTripper that proxies request using domain


### PR DESCRIPTION
mostly the reason for this cleanup is - our over-use of init() function causes extra logs to leak out before Flashlight is actually initialized

oh, and I removed references to Staging, since... it doesn't exist.