### PR TITLE
change email so filtering is easier later

### DIFF
--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -31,7 +31,7 @@ func TestSendReport(t *testing.T) {
 		int(Request_NO_ACCESS),
 		"Description placeholder",
 		"pro",
-		"thomas+test@getlantern.org",
+		"thomas+flashlighttest@getlantern.org",
 		"7.1.1",
 		"Samsung Galaxy S10",
 		"SM-G973F",


### PR DESCRIPTION
The help desk portal is getting a bunch of tickets created from this, which is good because it means issues submitted from flashlight are created successfully, but bad because there are a bunch of tickets flooding the help desk (and I am getting a bunch of emails from them). 