### PR TITLE
Do not use proxyless if proxy all is set

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -754,6 +754,7 @@ func (client *Client) initDialers(proxies map[string]*commonconfig.ProxyConfig) 
 			OnNewDialer: func(dialer dialer.Dialer) {
 				client.dialer.set(dialer)
 			},
+			ProxyAll: client.proxyAll,
 		},
 	)
 	client.dialer.set(newDialer)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -85,6 +85,9 @@ func resetDialers(client *Client, dial func(network, addr string) (net.Conn, err
 			default:
 			}
 		},
+		ProxyAll: func() bool {
+			return false
+		},
 	})
 	client.dialer.set(d)
 	// Wait for the dialer to be ready

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -47,6 +47,10 @@ type Options struct {
 	proxylessDialer proxyless
 
 	OnNewDialer func(Dialer)
+
+	// Specifies whether or not to proxy all traffic. In this case, that means bypasses the proxyless
+	// dialer and uses the proxy dialers to connect to the destination site.
+	ProxyAll func() bool
 }
 
 // Clone creates a deep copy of the Options object
@@ -61,6 +65,7 @@ func (o *Options) Clone() *Options {
 		BanditDir:       o.BanditDir,
 		proxylessDialer: o.proxylessDialer,
 		OnNewDialer:     o.OnNewDialer,
+		ProxyAll:        o.ProxyAll,
 	}
 }
 

--- a/dialer/fastconnect.go
+++ b/dialer/fastconnect.go
@@ -56,7 +56,7 @@ func newFastConnectDialer(opts *Options) *fastConnectDialer {
 			} else {
 				if opts.OnNewDialer != nil {
 					log.Debug("Switching to bandit dialer")
-					opts.OnNewDialer(newParallelPreferProxyless(opts.proxylessDialer, banditDialer))
+					opts.OnNewDialer(newParallelPreferProxyless(opts.proxylessDialer, banditDialer, opts))
 				} else {
 					log.Errorf("No onNewDialer function set -- should never happen")
 				}

--- a/dialer/parallel_dialer.go
+++ b/dialer/parallel_dialer.go
@@ -21,7 +21,7 @@ func newParallelPreferProxyless(proxyless proxyless, d Dialer, opts *Options) Di
 }
 
 func (d *parallelDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	if d.opts.ProxyAll() {
+	if d.opts != nil && d.opts.ProxyAll() {
 		// If the user has requested to proxy all traffic, we fall back to the default dialer.
 		return d.dialer.DialContext(ctx, network, addr)
 	}

--- a/dialer/parallel_dialer.go
+++ b/dialer/parallel_dialer.go
@@ -21,7 +21,7 @@ func newParallelPreferProxyless(proxyless proxyless, d Dialer, opts *Options) Di
 }
 
 func (d *parallelDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	if d.opts != nil && d.opts.ProxyAll() {
+	if d.opts != nil && d.opts.ProxyAll != nil && d.opts.ProxyAll() {
 		// If the user has requested to proxy all traffic, we fall back to the default dialer.
 		return d.dialer.DialContext(ctx, network, addr)
 	}

--- a/dialer/parallel_dialer.go
+++ b/dialer/parallel_dialer.go
@@ -9,16 +9,22 @@ import (
 type parallelDialer struct {
 	proxylessDialer proxyless
 	dialer          Dialer
+	opts            *Options
 }
 
-func newParallelPreferProxyless(proxyless proxyless, d Dialer) Dialer {
+func newParallelPreferProxyless(proxyless proxyless, d Dialer, opts *Options) Dialer {
 	return &parallelDialer{
 		proxylessDialer: proxyless,
 		dialer:          d,
+		opts:            opts,
 	}
 }
 
 func (d *parallelDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if d.opts.ProxyAll() {
+		// If the user has requested to proxy all traffic, we fall back to the default dialer.
+		return d.dialer.DialContext(ctx, network, addr)
+	}
 	switch d.proxylessDialer.status(addr) {
 	case SUCCEEDED:
 		// If the proxyless dialer is succeeding, keep using it.

--- a/dialer/proxyless.go
+++ b/dialer/proxyless.go
@@ -153,7 +153,7 @@ func (d *proxylessDialer) status(address string) int {
 func (d *proxylessDialer) OnOptions(opts *Options) Dialer {
 	log.Debugf("OnOptions called on proxylessDialer with %v dialers", len(opts.Dialers))
 	opts.proxylessDialer = d
-	return newParallelPreferProxyless(opts.proxylessDialer, newFastConnectDialer(opts))
+	return newParallelPreferProxyless(opts.proxylessDialer, newFastConnectDialer(opts), opts)
 }
 
 // Close closes the dialer and cleans up any resources


### PR DESCRIPTION
This pull request introduces a new feature to support the "Proxy All" functionality, which allows all traffic to bypass the proxyless dialer and use proxy dialers instead. The changes involve updates to several files to integrate this feature seamlessly into the existing dialer framework.

### Addition of "Proxy All" Functionality:
* [`dialer/dialer.go`](diffhunk://#diff-7c30b4c07a2428a311d85ea496b701435b8cb1aa63330194c349598b2564e71cR50-R53): Added a new `ProxyAll` field to the `Options` struct, which is a function determining whether all traffic should be proxied. Updated the `Clone` method to include the `ProxyAll` field. [[1]](diffhunk://#diff-7c30b4c07a2428a311d85ea496b701435b8cb1aa63330194c349598b2564e71cR50-R53) [[2]](diffhunk://#diff-7c30b4c07a2428a311d85ea496b701435b8cb1aa63330194c349598b2564e71cR68)

### Integration with Dialer Logic:
* [`dialer/parallel_dialer.go`](diffhunk://#diff-644502997a8a0566b69ecedfe105a728c7f908dadc30a0168bc08f86a0137215R12-R27): Modified the `parallelDialer` struct to include the `Options` pointer and updated the `newParallelPreferProxyless` function to accept `Options`. Added logic in the `DialContext` method to check `ProxyAll` and bypass the proxyless dialer if necessary.
* [`dialer/fastconnect.go`](diffhunk://#diff-f3c0b2afcf96a34438b8c333aef940c050209b25e7504ac3daa1b8488830bacbL59-R59): Updated the `newFastConnectDialer` function to pass the `Options` object to `newParallelPreferProxyless`, ensuring the "Proxy All" logic is respected.
* [`dialer/proxyless.go`](diffhunk://#diff-53feb544f2937a69dec71cfc12f6c3769f558ef98caa83c4f607a36128efbbc1L156-R156): Updated the `OnOptions` method to pass the `Options` object to `newParallelPreferProxyless`, maintaining consistency across dialers.

### Client Configuration:
* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R757): Updated the `initDialers` method to set the `ProxyAll` function in the dialer options, enabling the feature at the client level.