### PR TITLE
Exclude IP addresses from proxyless dialing

### DIFF
--- a/dialer/proxyless.go
+++ b/dialer/proxyless.go
@@ -208,7 +208,12 @@ func normalizeAddrHost(address string) (string, string, error) {
 }
 
 func isIPAddress(ip string) bool {
-	parsedIP := net.ParseIP(ip)
+	// First split the IP address by host and port
+	host, _, err := net.SplitHostPort(ip)
+	if err != nil { // If there's no port, we assume it's just an IP address
+		host = ip
+	}
+	parsedIP := net.ParseIP(host)
 	return parsedIP != nil
 }
 

--- a/dialer/proxyless.go
+++ b/dialer/proxyless.go
@@ -142,6 +142,10 @@ func (d *proxylessDialer) onFailure(host string, err error) {
 // status checks the status of the dialer for the given address.
 // Returns SUCCEEDED, FAILED, or UNKNOWN.
 func (d *proxylessDialer) status(address string) int {
+	if isIPAddress(address) {
+		// If the address is an IP address, we can't use the proxyless dialer.
+		return FAILED
+	}
 	_, host, err := normalizeAddrHost(address)
 	if err != nil {
 		return FAILED
@@ -201,6 +205,11 @@ func normalizeAddrHost(address string) (string, string, error) {
 	}
 	addr := fmt.Sprintf("%s:%s", host, "443")
 	return addr, host, nil
+}
+
+func isIPAddress(ip string) bool {
+	parsedIP := net.ParseIP(ip)
+	return parsedIP != nil
 }
 
 // configBytes returns the configuration bytes for the smart dialer

--- a/dialer/proxyless_test.go
+++ b/dialer/proxyless_test.go
@@ -148,3 +148,26 @@ func TestDialContext_DialStreamError(t *testing.T) {
 	assert.Nil(t, conn)
 	assert.Error(t, err)
 }
+func TestIsIPAddress(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"127.0.0.1", true},
+		{"192.168.1.1", true},
+		{"::1", true},
+		{"2001:db8::1", true},
+		{"example.com", false},
+		{"localhost", false},
+		{"", false},
+		{"256.256.256.256", false},        // invalid IP
+		{"1234:5678:9abc:defg::1", false}, // invalid IPv6
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := isIPAddress(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/dialer/proxyless_test.go
+++ b/dialer/proxyless_test.go
@@ -155,6 +155,7 @@ func TestIsIPAddress(t *testing.T) {
 	}{
 		{"127.0.0.1", true},
 		{"192.168.1.1", true},
+		{"192.168.1.1:90", true},
 		{"::1", true},
 		{"2001:db8::1", true},
 		{"example.com", false},
@@ -162,6 +163,7 @@ func TestIsIPAddress(t *testing.T) {
 		{"", false},
 		{"256.256.256.256", false},        // invalid IP
 		{"1234:5678:9abc:defg::1", false}, // invalid IPv6
+		{"127.0.0.1:8080", true},          // port included
 	}
 
 	for _, tt := range tests {

--- a/dialer/proxyless_test.go
+++ b/dialer/proxyless_test.go
@@ -164,6 +164,7 @@ func TestIsIPAddress(t *testing.T) {
 		{"256.256.256.256", false},        // invalid IP
 		{"1234:5678:9abc:defg::1", false}, // invalid IPv6
 		{"127.0.0.1:8080", true},          // port included
+		{"[2001:db8::1]:8080", true},      // IPv6 with port
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Proxyless can't do anything with IP addresses, so we shouldn't try.