### PR TITLE
Add support for setting allowed transports in the environment

### DIFF
--- a/chained/proxy.go
+++ b/chained/proxy.go
@@ -98,6 +98,10 @@ func CreateDialersMap(configDir string, proxies map[string]*config.ProxyConfig, 
 				wg.Add(1)
 				go func(name string, s *config.ProxyConfig) {
 					defer wg.Done()
+					if !common.SupportsTransport(s.PluggableTransport) {
+						log.Debugf("Ignoring dialer for %v with transport %v not in %v", name, s.PluggableTransport, os.Getenv("LANTERN_TRANSPORTS"))
+						return
+					}
 					dialer, err := CreateDialer(configDir, name, s, uc)
 					if err != nil {
 						log.Errorf("Unable to configure chained server %v. Received error: %v", name, err)

--- a/common/httpclient.go
+++ b/common/httpclient.go
@@ -52,7 +52,7 @@ func GetHTTPClient() *http.Client {
 	}
 
 	var k kindling.Kindling
-	ioWriter := log.AsStdLogger().Writer()
+	ioWriter := log.AsDebugLogger().Writer()
 	// Create new fronted instance.
 	f, err := newFronted(ioWriter, sentry.PanicListener)
 	if err != nil {

--- a/common/lanternconfig.go
+++ b/common/lanternconfig.go
@@ -1,5 +1,11 @@
 package common
 
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
 const (
 	// The default name for this app (used if no client-supplied name is passed at initialization)
 	DefaultAppName = "Lantern"
@@ -10,3 +16,24 @@ const (
 	// TrackingID is the Google Analytics tracking ID.
 	TrackingID = "UA-21815217-12"
 )
+
+var transports = loadTransports()
+
+func loadTransports() []string {
+	env := os.Getenv("LANTERN_TRANSPORTS")
+	if env == "" {
+		return []string{}
+	}
+	parts := strings.Split(env, ",")
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+	}
+	return parts
+}
+
+// SupportsTransport reads the LANTERN_TRANSPORTS environment variable and returns whether or not the
+// specified transport is supported. If the there is no LANTERN_TRANSPORTS environment variable defined,
+// all transports are supported.
+func SupportsTransport(transport string) bool {
+	return len(transports) == 0 || slices.Contains(transports, transport)
+}

--- a/common/lanternconfig.go
+++ b/common/lanternconfig.go
@@ -32,7 +32,7 @@ func loadTransports() []string {
 }
 
 // SupportsTransport reads the LANTERN_TRANSPORTS environment variable and returns whether or not the
-// specified transport is supported. If the there is no LANTERN_TRANSPORTS environment variable defined,
+// specified transport is supported. If there is no LANTERN_TRANSPORTS environment variable defined,
 // all transports are supported.
 func SupportsTransport(transport string) bool {
 	return len(transports) == 0 || slices.Contains(transports, transport)

--- a/common/lanternconfig_test.go
+++ b/common/lanternconfig_test.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestLoadTransports_EmptyEnv(t *testing.T) {
+	orig := os.Getenv("LANTERN_TRANSPORTS")
+	defer os.Setenv("LANTERN_TRANSPORTS", orig)
+
+	os.Unsetenv("LANTERN_TRANSPORTS")
+	got := loadTransports()
+	want := []string{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected %v, got %v", want, got)
+	}
+}
+
+func TestLoadTransports_SingleTransport(t *testing.T) {
+	orig := os.Getenv("LANTERN_TRANSPORTS")
+	defer os.Setenv("LANTERN_TRANSPORTS", orig)
+
+	os.Setenv("LANTERN_TRANSPORTS", "obfs4")
+	got := loadTransports()
+	want := []string{"obfs4"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected %v, got %v", want, got)
+	}
+}
+
+func TestLoadTransports_MultipleTransports(t *testing.T) {
+	orig := os.Getenv("LANTERN_TRANSPORTS")
+	defer os.Setenv("LANTERN_TRANSPORTS", orig)
+
+	os.Setenv("LANTERN_TRANSPORTS", "obfs4, meek,  shadowsocks ")
+	got := loadTransports()
+	want := []string{"obfs4", "meek", "shadowsocks"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected %v, got %v", want, got)
+	}
+}
+
+func TestLoadTransports_WhitespaceOnly(t *testing.T) {
+	orig := os.Getenv("LANTERN_TRANSPORTS")
+	defer os.Setenv("LANTERN_TRANSPORTS", orig)
+
+	os.Setenv("LANTERN_TRANSPORTS", "   ")
+	got := loadTransports()
+	want := []string{""}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected %v, got %v", want, got)
+	}
+}

--- a/dialer/parallel_dialer.go
+++ b/dialer/parallel_dialer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net"
+
+	"github.com/getlantern/flashlight/v7/common"
 )
 
 type parallelDialer struct {
@@ -21,6 +23,11 @@ func newParallelPreferProxyless(proxyless proxyless, d Dialer, opts *Options) Di
 }
 
 func (d *parallelDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if !common.SupportsTransport("proxyless") {
+		log.Debugf("Proxyless transport not supported, falling back to default dialer for %s", addr)
+		// If the proxyless transport is not supported, we fall back to the default dialer.
+		return d.dialer.DialContext(ctx, network, addr)
+	}
 	switch d.proxylessDialer.status(addr) {
 	case SUCCEEDED:
 		log.Debugf("Proxyless dialer succeeded for %s, using it", addr)


### PR DESCRIPTION
This allows developers to set the LANTERN_TRANSPORTS from the environment. For example, you can run, from lantern-client:

```
LANTERN_TRANSPORTS=broflake flutter run -d macos
```
or

```
LANTERN_TRANSPORTS="broflake,proxyless" flutter run -d macos
```