### PR TITLE
support running multiple DoH/DoT DNSTT tunnels

### DIFF
--- a/common/httpclient_test.go
+++ b/common/httpclient_test.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDNSResolvers(t *testing.T) {
+	t.Skip("Skipping DNS resolver tests for github")
+
+	t.Run("DNS over HTTPS", func(t *testing.T) {
+		client := &http.Client{Timeout: 5 * time.Second}
+		failed := []string{}
+		for _, host := range dohResolvers {
+			req, err := http.NewRequest("GET", host+"?dns=AAABAAABAAAAAAAAB2V4YW1wbGUDY29tAAABAAE", nil)
+			req.Header.Set("Accept", "application/dns-message")
+			resp, err := client.Do(req)
+			if !assert.NoError(t, err) {
+				failed = append(failed, host)
+				continue
+			}
+			_, err = io.ReadAll(resp.Body)
+			if !assert.NoError(t, err) {
+				resp.Body.Close()
+				continue
+			}
+			resp.Body.Close()
+		}
+		assert.Empty(t, failed, "All DNS over TLS resolvers failed")
+	})
+	t.Run("DNS over TLS", func(t *testing.T) {
+		t.Skip("")
+		failed := []string{}
+		for _, host := range dotResolvers {
+			t.Logf("Testing DNS over TLS resolver: %s", host)
+			resolver := net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					cfg := &tls.Config{
+						ServerName:         host,
+						InsecureSkipVerify: true,
+					}
+					addr = net.JoinHostPort(host, "853")
+					return tls.DialWithDialer(new(net.Dialer), "tcp", addr, cfg)
+				},
+			}
+			ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+			resp, err := resolver.LookupHost(ctx, "google.com")
+			if !assert.NoError(t, err) {
+				failed = append(failed, host)
+				continue
+			}
+			assert.Greater(t, len(resp), 0, "Expected at least one answer from %s", host)
+		}
+		assert.Empty(t, failed, "All DNS over TLS resolvers failed")
+	})
+}


### PR DESCRIPTION
This pull request introduces support for multiple DNS-over-HTTPS (DoH) and DNS-over-TLS (DoT) resolvers in the `common/httpclient.go` file, replacing the previous single-resolver approach. It also includes a new test suite to validate the functionality of these resolvers. 

### Enhancements to DNS Resolver Functionality:

* **Support for Multiple Resolvers**: Added lists of predefined DoH and DoT resolvers (`dohResolvers` and `dotResolvers`) to enable the creation of multiple DNS tunnels. (`common/httpclient.go`, [common/httpclient.goR43-R64](diffhunk://#diff-485d80568d05d3233923ec91d33f7b5f7dc69b223d233809b6f8a794589494d1R43-R64))
* **Refactored `newDNSTT` to `newDNSTTs`**: The function now initializes multiple `DNSTT` instances using all resolvers in the lists, instead of a single instance based on a single resolver. (`common/httpclient.go`, [[1]](diffhunk://#diff-485d80568d05d3233923ec91d33f7b5f7dc69b223d233809b6f8a794589494d1L157-R181) [[2]](diffhunk://#diff-485d80568d05d3233923ec91d33f7b5f7dc69b223d233809b6f8a794589494d1L167-R211)
* **Updated HTTP Client Initialization**: Modified `GetHTTPClient` to integrate multiple DNS tunnels into the HTTP client configuration. (`common/httpclient.go`, [common/httpclient.goL100-R128](diffhunk://#diff-485d80568d05d3233923ec91d33f7b5f7dc69b223d233809b6f8a794589494d1L100-R128))

### Testing Improvements:

* **New Test Suite**: Added `TestDNSResolvers` in `common/httpclient_test.go` to validate each DoH/DoT provider.