### PR TITLE
Adds ability for the user to set whether or not proxyless should be used

### DIFF
--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -48,9 +48,9 @@ type Options struct {
 
 	OnNewDialer func(Dialer)
 
-	// Specifies whether or not to proxy all traffic. In this case, that means bypasses the proxyless
-	// dialer and uses the proxy dialers to connect to the destination site.
-	ProxyAll func() bool
+	// Specifies whether or not to enable proxyless dialing for all traffic. Proxyless is
+	// off when proxy all is on.
+	UseProxyless func() bool
 }
 
 // Clone creates a deep copy of the Options object
@@ -65,7 +65,7 @@ func (o *Options) Clone() *Options {
 		BanditDir:       o.BanditDir,
 		proxylessDialer: o.proxylessDialer,
 		OnNewDialer:     o.OnNewDialer,
-		ProxyAll:        o.ProxyAll,
+		UseProxyless:    o.UseProxyless,
 	}
 }
 

--- a/dialer/parallel_dialer.go
+++ b/dialer/parallel_dialer.go
@@ -23,8 +23,7 @@ func newParallelPreferProxyless(proxyless proxyless, d Dialer, opts *Options) Di
 }
 
 func (d *parallelDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	if !common.SupportsProxyless() {
-		log.Debugf("Proxyless transport not supported, falling back to default dialer for %s", addr)
+	if !common.SupportsProxyless() || !d.opts.UseProxyless() {
 		// If the proxyless transport is not supported, we fall back to the default dialer.
 		return d.dialer.DialContext(ctx, network, addr)
 	}

--- a/flashlight.go
+++ b/flashlight.go
@@ -84,6 +84,7 @@ type Flashlight struct {
 	errorHandler     func(HandledErrorType, error)
 	mxProxyListeners sync.RWMutex
 	proxyListeners   []func(map[string]*commonconfig.ProxyConfig, config.Source)
+	useProxyless     func() bool
 }
 
 // clientCallbacks are callbacks the client is configured with
@@ -215,7 +216,6 @@ func New(
 	useDetour := func() bool {
 		return !_proxyAll() && f.featureEnabled(config.FeatureDetour) && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
 	}
-
 	proxyAll := func() bool {
 		useShortcutOrDetour := useShortcut() || useDetour()
 		return !useShortcutOrDetour && !f.featureEnabled(config.FeatureProxyWhitelistedOnly)
@@ -243,6 +243,7 @@ func New(
 		eventWithLabel,
 		f.callbacks.onDialError,
 		f.callbacks.onSucceedingProxy,
+		f.useProxyless,
 	)
 
 	if err != nil {

--- a/option.go
+++ b/option.go
@@ -42,3 +42,10 @@ func WithOnProxies(onProxiesUpdate func([]dialer.ProxyDialer, config.Source)) Op
 		client.callbacks.onProxiesUpdate = onProxiesUpdate
 	}
 }
+
+// WithUseProxyless sets the function to determine if proxyless dialing should be used.
+func WithUseProxyless(useProxyless func() bool) Option {
+	return func(client *Flashlight) {
+		client.useProxyless = useProxyless
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `useProxyless` function to enable or disable proxyless dialing dynamically across the application. The changes primarily involve replacing the previous `ProxyAll` functionality with `UseProxyless` and updating the relevant code to reflect this new approach. Below are the key changes grouped by theme:

### Client Updates:
* Added a `useProxyless` field to the `Client` struct in `client/client.go`, allowing the client to determine whether to use proxyless dialing dynamically.
* Updated the `NewClient` constructor to accept the `useProxyless` function and initialize it in the `Client` struct. [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R172) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R209)
* Modified the `initDialers` method to pass the `useProxyless` function to the dialer options instead of the previous `proxyAll` function.

### Dialer Updates:
* Replaced the `ProxyAll` field in the `Options` struct with `UseProxyless`, and updated the corresponding comments to reflect the new functionality in `dialer/dialer.go`.
* Updated the `Clone` method of the `Options` struct to include the new `UseProxyless` field.
* Modified the `newParallelPreferProxyless` function in `dialer/parallel_dialer.go` to check both `common.SupportsProxyless()` and the `UseProxyless` function before falling back to the default dialer.

### Flashlight Updates:
* Added a `useProxyless` field to the `Flashlight` struct in `flashlight.go` to propagate the proxyless functionality.
* Updated the `New` function in `flashlight.go` to pass the `useProxyless` function to the client during initialization.

### Option Enhancements:
* Introduced a new `WithUseProxyless` option in `option.go` to allow external configuration of the `useProxyless` function for the `Flashlight` client.