### PR TITLE
fix exponential backoff overflow

### DIFF
--- a/services/http.go
+++ b/services/http.go
@@ -16,7 +16,7 @@ const (
 )
 
 // sender is a helper for sending post requests. If the request fails, sender calculates an
-// exponential backoff time using retryWaitSeconds and return it as the sleep time.
+// exponential backoff time using minRetryWait and return it as the sleep time.
 type sender struct {
 	nextWait time.Duration
 }

--- a/services/http.go
+++ b/services/http.go
@@ -15,7 +15,7 @@ const (
 	maxRetryWait = 10 * time.Minute
 )
 
-// sender is a helper for sending post requests. If the request fails, sender calulates an
+// sender is a helper for sending post requests. If the request fails, sender calculates an
 // exponential backoff time using retryWaitSeconds and return it as the sleep time.
 type sender struct {
 	nextWait time.Duration


### PR DESCRIPTION
The `backoff` function's wait time calculation completely overflows `time.Duration` on the 55th retry (approximately after 6 hours). This results in zero wait times, leading to the uncontrolled spawn of hundreds of goroutines, which can cause memory exhaustion and OOM kill on linux.