### PR TITLE
Migrate tester OTel export from Honeycomb to SigNoz

### DIFF
--- a/services/http_test.go
+++ b/services/http_test.go
@@ -34,7 +34,7 @@ func TestPost(t *testing.T) {
 	testBackoff := func(t *testing.T, rt *mockRoundTripper) {
 		sdr := &sender{}
 		for i := 0; i < 5; i++ {
-			wait := time.Duration(math.Pow(2, float64(i))) * retryWaitSeconds
+			wait := time.Duration(math.Pow(2, float64(i))) * minRetryWait
 			want := int64(wait.Seconds())
 			req, _ := http.NewRequest(http.MethodPost, "http://example.com", nil)
 			_, sleep, err = sdr.post(req, &http.Client{Transport: rt})

--- a/tester/main.go
+++ b/tester/main.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/getlantern/flashlight/v7"
 	"github.com/getlantern/flashlight/v7/client"
 	"github.com/getlantern/flashlight/v7/common"
@@ -20,17 +18,16 @@ import (
 	"github.com/getlantern/ops"
 )
 
-func configureOtel(country, signozKey string) {
-	runId := uuid.NewString()
+func configureOtel(runId, country, signozKey string) {
 	fmt.Printf("performing lantern ping: url=%s\n", country)
 	fmt.Printf("lookup traces on SigNoz with pinger-id=%s\n  https://lantern.us.signoz.cloud/traces-explorer\n", runId)
+	ops.SetGlobal("pinger-id", runId)
 	flashlightOtel.ConfigureOnce(&flashlightOtel.Config{
 		Endpoint: "ingest.us.signoz.cloud:443",
 		Headers: map[string]string{
 			"signoz-ingestion-key": signozKey,
 		},
 	}, "pinger")
-	ops.SetGlobal("pinger-id", runId)
 }
 
 func performLanternPing(urlToHit string, runId string, deviceId string, userId int64, token string, dataDir string, isSticky bool, signozKey string) error {
@@ -42,7 +39,7 @@ func performLanternPing(urlToHit string, runId string, deviceId string, userId i
 	statsTracker := stats.NewTracker()
 	var onOneProxy sync.Once
 	proxyReady := make(chan struct{})
-	configureOtel(urlToHit, signozKey)
+	configureOtel(runId, urlToHit, signozKey)
 	common.LibraryVersion = "999.999.999"
 	fc, err := flashlight.New(
 		"pinger",

--- a/tester/main.go
+++ b/tester/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -21,23 +20,20 @@ import (
 	"github.com/getlantern/ops"
 )
 
-func configureOtel(country string) {
-	// Configure OpenTelemetry
-	const replacementText = "UUID-GOES-HERE"
-	const honeycombQueryTemplate = `https://ui.honeycomb.io/lantern-bc/environments/prod/datasets/flashlight?query=%7B%22time_range%22%3A300%2C%22granularity%22%3A15%2C%22breakdowns%22%3A%5B%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22pinger-id%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22UUID-GOES-HERE%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%5D%2C%22havings%22%3A%5B%5D%2C%22trace_joins%22%3A%5B%5D%2C%22limit%22%3A100%7D`
+func configureOtel(country, signozKey string) {
 	runId := uuid.NewString()
 	fmt.Printf("performing lantern ping: url=%s\n", country)
-	fmt.Printf("lookup traces on Honeycomb with pinger-id: %s, link: %s\n", runId, strings.ReplaceAll(honeycombQueryTemplate, replacementText, runId))
+	fmt.Printf("lookup traces on SigNoz with pinger-id=%s\n  https://lantern.us.signoz.cloud/traces-explorer\n", runId)
 	flashlightOtel.ConfigureOnce(&flashlightOtel.Config{
-		Endpoint: "api.honeycomb.io:443",
+		Endpoint: "ingest.us.signoz.cloud:443",
 		Headers: map[string]string{
-			"x-honeycomb-team": "vuWkzaeefr2OcL1SfowtuG",
+			"signoz-ingestion-key": signozKey,
 		},
 	}, "pinger")
 	ops.SetGlobal("pinger-id", runId)
 }
 
-func performLanternPing(urlToHit string, runId string, deviceId string, userId int64, token string, dataDir string, isSticky bool) error {
+func performLanternPing(urlToHit string, runId string, deviceId string, userId int64, token string, dataDir string, isSticky bool, signozKey string) error {
 	golog.SetPrepender(func(writer io.Writer) {
 		_, _ = writer.Write([]byte(fmt.Sprintf("%s: ", time.Now().Format("2006-01-02 15:04:05"))))
 	})
@@ -46,7 +42,7 @@ func performLanternPing(urlToHit string, runId string, deviceId string, userId i
 	statsTracker := stats.NewTracker()
 	var onOneProxy sync.Once
 	proxyReady := make(chan struct{})
-	configureOtel(urlToHit)
+	configureOtel(urlToHit, signozKey)
 	common.LibraryVersion = "999.999.999"
 	fc, err := flashlight.New(
 		"pinger",
@@ -156,11 +152,12 @@ func main() {
 	runId := os.Getenv("RUN_ID")
 	targetUrl := os.Getenv("TARGET_URL")
 	data := os.Getenv("DATA")
+	signozKey := os.Getenv("SIGNOZ_INGESTION_KEY")
 	isSticky := os.Getenv("STICKY") == "true"
 
-	if deviceId == "" || userId == "" || token == "" || runId == "" || targetUrl == "" || data == "" {
+	if deviceId == "" || userId == "" || token == "" || runId == "" || targetUrl == "" || data == "" || signozKey == "" {
 		fmt.Println("missing required environment variable(s)")
-		fmt.Println("Required environment variables: DEVICE_ID, USER_ID, TOKEN, RUN_ID, TARGET_URL, DATA")
+		fmt.Println("Required environment variables: DEVICE_ID, USER_ID, TOKEN, RUN_ID, TARGET_URL, DATA, SIGNOZ_INGESTION_KEY")
 		os.Exit(1)
 	}
 
@@ -170,7 +167,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if performLanternPing(targetUrl, runId, deviceId, uid, token, data, isSticky) != nil {
+	if performLanternPing(targetUrl, runId, deviceId, uid, token, data, isSticky, signozKey) != nil {
 		fmt.Println("failed to perform lantern ping")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Tester now reads `SIGNOZ_INGESTION_KEY` from env and hard-fails if unset. Endpoint swapped to `ingest.us.signoz.cloud:443`; header swapped to `signoz-ingestion-key`. Honeycomb query-URL template removed — replaced with a plain SigNoz explorer link plus the `pinger-id`.

Also includes a one-line fix for services/http_test.go — `retryWaitSeconds` was renamed to `minRetryWait` in 2fd20ca90 / 332d3e3dc but the test file was left dangling, so main has been failing to build since. Bundled here to unblock CI on this PR; no behavior change (same 5s value).

Merge order across the honeycomb-removal track:

- https://github.com/getlantern/lantern-cloud/pull/2977 — first (removes honeycomb vault grants + drops HONEYCOMB_API_KEY from ops)
- https://github.com/getlantern/lantern-cloud/pull/3184 — second (pinger reads and injects `SIGNOZ_INGESTION_KEY` into tester env)
- this PR — third (CI rebuilds `flashlight-tester:latest`; pinger's next lantern-ping supplies the env var it now requires)

If this lands before #3184 is fully rolled out, pinger's next ping call hard-exits on missing env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run tracking in telemetry so diagnostic data is consistently associated with the correct run.
  * Refined retry timing validation to better reflect the service’s configured backoff behavior.
  * Preserved existing validation for required configuration and telemetry ingestion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->