### PR TITLE
Fix SOCKS5 dial failure for IPv6 destinations

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -331,7 +331,7 @@ func (client *Client) ListenAndServeSOCKS5(requestedAddr string) error {
 			op := ops.Begin("proxy")
 			defer op.End()
 
-			host := fmt.Sprintf("%v:%v", req.DestAddr.IP, req.DestAddr.Port)
+			host := net.JoinHostPort(req.DestAddr.IP.String(), strconv.Itoa(req.DestAddr.Port))
 			addr, err := client.reverseDNS(host)
 			if err != nil {
 				return op.FailIf(log.Errorf("Error performing reverseDNS for %v: %v", host, err))


### PR DESCRIPTION
## Summary
- `ListenAndServeSOCKS5`'s `HandleConnect` built the destination `host:port` string with `fmt.Sprintf("%v:%v", req.DestAddr.IP, req.DestAddr.Port)`, which doesn't bracket IPv6 addresses. A destination like `2606:4700:10::6814:179a:443` is ambiguous to `net.Dial`/`net.SplitHostPort` and fails with `too many colons in address`.
- Switched to `net.JoinHostPort`, which brackets IPv6 hosts automatically (`[2606:4700:10::6814:179a]:443`) and is a no-op for IPv4/hostnames.

## Impact
- Found while testing a new IPv6 proxy route with `flashlight-tester`: the chained-proxy handshake succeeded, but the final local SOCKS5 → destination dial failed whenever the client's local DNS resolution returned an IPv6 (AAAA) address for the target.
- VPN-mode clients (mobile, full tunnel) aren't affected — `dnsgrab` hands local apps fake IPv4 addresses and reverse-resolves to a hostname before dialing, so a real IPv6 address never reaches this code path (`flashlight.go:172-208`).
- Desktop-app / proxy-only modes without full VPN interception *are* affected, since the local browser/app resolves DNS itself and can hand flashlight a real IPv6 destination directly. Exposure grows as more sites/networks prefer IPv6.
- This is a client-side bug baked into already-installed binaries — it can't be mitigated server-side and needs a shipped update to reach affected users.

## Test plan
- [ ] Reproduced pre-fix with `flashlight-tester` against a working chained proxy and a `TARGET_URL` that locally resolves to IPv6 — got `too many colons in address`.
- [ ] Rebuilt with the fix and confirmed the SOCKS5 dial no longer errors on an IPv6 destination.
- [ ] Confirmed IPv4 destinations are unaffected (unchanged output from `net.JoinHostPort` for non-IPv6 hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SOCKS5 connection handling for IPv6 destinations by correctly formatting host and port addresses.
  - IPv4 connection behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->